### PR TITLE
Remove ETA for first data dump.

### DIFF
--- a/webserver/templates/index/home.html
+++ b/webserver/templates/index/home.html
@@ -12,7 +12,6 @@
     AcousticBrainz. Submission to MessyBrainz is restricted, however the
     resulting data will be made freely availalbe.</p>
 
-    <p>The first MessyBrainz data dump will be made available on October 30 2015.</p>
     <div class="row">
         <div class="col-lg-2"></div>
       <div class="col-lg-4">


### PR DESCRIPTION
"October 30 2015" has come and gone and first data dump is nowhere in sight. Let's remove the ETA and post something when we actually know something.
