### PR TITLE
Reference keys of config object with dict notation

### DIFF
--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -38,7 +38,7 @@ def create_app():
 
     @app.before_request
     def before_request():
-        db.init_db_engine(app.config.SQLALCHEMY_DATABASE_URI)
+        db.init_db_engine(app.config['SQLALCHEMY_DATABASE_URI'])
 
     @app.teardown_request
     def teardown_request(exception):


### PR DESCRIPTION
Previously on each access of running server error was printed:

```
AttributeError: 'Config' object has no attribute
'SQLALCHEMY_DATABASE_URI'
```
