### PR TITLE
Fix docs: how to run server with `manage.py runserver`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,6 +46,13 @@ After you tweak configuration file, database needs to be created:
 
 ### Starting the server
 
-After all this, you can run the site/server using `./server.py`.
-Use `./server.py -h` to get a list of command-line switches
-to further suit your local environment (e.g., port, listening address, ...).
+After all this, you can run the site/server using:
+
+    $ python manage.py runserver
+
+Use:
+
+    $ python manage.py runserver --help
+
+to get a list of command-line switches to further suit your local environment
+(e.g., port, listening address, ...).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can start the web server (will be available at http://127.0.0.1:8080/):
 
     $ vagrant ssh
     $ cd messybrainz-server
-    $ python server.py
+    $ python manage.py runserver
 
 There are some shortcuts defined using fabric to perform commonly used
 commands:


### PR DESCRIPTION
File `server.py` no longer exist since commit 35d75ef and same
functionality can be achieved by `manage.py runserver`.

Also use same notation to invoke commands - code block instead of
inline code.
