### PR TITLE
LB-239: Upgrade psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Werkzeug == 0.10.4
 click == 4.1
 coverage == 3.7.1
 nose == 1.3.7
-psycopg2 == 2.6.1
+psycopg2 == 2.7.3.2
 redis == 2.10.3
 raven[flask] == 5.5.0
 setproctitle == 1.1.9


### PR DESCRIPTION
LB's build is broken because of a bug in the version of psycopg2 we use (https://github.com/psycopg/psycopg2/issues/594). Upgrading fixes this.