### PR TITLE
Upgrade brainzutils to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/metabrainz/brainzutils-python.git@v1.1.0
+git+https://github.com/metabrainz/brainzutils-python.git@v1.3.0
 Fabric == 1.10.2
 Flask == 0.10.1
 Flask-Testing == 0.4.2


### PR DESCRIPTION
1.3.0 is the version we use in current LB, so keeping it the
same here is a good idea.