### PR TITLE
LB-86: Add support for creation of data dumps from manage.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
                        build-essential \
                        redis-tools \
                        libpq-dev \
+                       pxz \
                        git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -64,4 +64,9 @@ CREATE TABLE release_cluster (
   updated     TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
+CREATE TABLE data_dump (
+  id          SERIAL,
+  created     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
 COMMIT;

--- a/admin/sql/drop_tables.sql
+++ b/admin/sql/drop_tables.sql
@@ -10,5 +10,6 @@ DROP TABLE IF EXISTS artist_credit_cluster  CASCADE;
 DROP TABLE IF EXISTS artist_credit_redirect CASCADE;
 DROP TABLE IF EXISTS release_cluster        CASCADE;
 DROP TABLE IF EXISTS release_redirect       CASCADE;
+DROP TABLE IF EXISTS data_dump              CASCADE;
 
 COMMIT;

--- a/admin/sql/updates/2017-12-31-add-data-dump-table.sql
+++ b/admin/sql/updates/2017-12-31-add-data-dump-table.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+CREATE TABLE data_dump (
+  id          SERIAL,
+  created     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+COMMIT;

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -10,6 +10,7 @@ RUN apt-get update \
                        redis-tools \
                        libpq-dev \
                        git \
+                       pxz \
     && rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client

--- a/manage.py
+++ b/manage.py
@@ -96,5 +96,8 @@ def init_test_db(force=False):
     print("Done!")
 
 
+import messybrainz.db.dump_manager as dump_manager
+cli.add_command(dump_manager.cli, name='dump')
+
 if __name__ == '__main__':
     cli()

--- a/messybrainz/db/__init__.py
+++ b/messybrainz/db/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 import sqlalchemy

--- a/messybrainz/db/dump.py
+++ b/messybrainz/db/dump.py
@@ -60,7 +60,14 @@ TABLES = (
 
 
 def dump_db(location, threads=None):
-    """ TODO
+    """ Create MessyBrainz database dump in the specified location
+
+        Arguments:
+            location: Directory where the final dump will be stored
+            threads: Maximal number of threads to run during compression, 1 if not specified
+
+        Returns:
+            Path to created dump.
     """
     create_path(location)
     dump_time = datetime.today()

--- a/messybrainz/db/dump.py
+++ b/messybrainz/db/dump.py
@@ -60,18 +60,18 @@ TABLES = (
 )
 
 
-def dump_db(location, threads=None):
+def dump_db(location, threads=None, dump_time=datetime.today()):
     """ Create MessyBrainz database dump in the specified location
 
         Arguments:
             location: Directory where the final dump will be stored
             threads: Maximal number of threads to run during compression, 1 if not specified
+            dump_time (datetime obj): the time when the dump was initiated
 
         Returns:
             Path to created dump.
     """
     create_path(location)
-    dump_time = datetime.today()
     archive_name = 'messybrainz-data-dump-{time}'.format(
         time=dump_time.strftime('%Y%m%d-%H%M%S')
     )

--- a/messybrainz/db/dump.py
+++ b/messybrainz/db/dump.py
@@ -1,0 +1,131 @@
+""" This module contains data dump creation and import functions
+"""
+
+# messybrainz-server - Server for the MessyBrainz project
+#
+# Copyright (C) 2017 MetaBrainz Foundation Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version. #
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA)
+
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+from datetime import datetime
+from messybrainz import db
+from messybrainz.db.utils import create_path
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                      'licenses', 'COPYING-PublicDomain')
+
+
+TABLES = (
+    'recording',
+    'recording_json',
+    'artist_credit',
+    'release',
+    'recording_redirect',
+    'recording_cluster',
+    'artist_credit_redirect',
+    'artist_credit_cluster',
+    'release_redirect',
+    'release_cluster',
+)
+
+
+def dump_db(location, threads=None):
+    """ TODO
+    """
+    create_path(location)
+    dump_time = datetime.today()
+    archive_name = 'messybrainz-data-dump-{time}'.format(
+        time=dump_time.strftime('%Y%m%d-%H%M%S')
+    )
+    archive_path = os.path.join(location, '{archive_name}.tar.xz'.format(
+        archive_name=archive_name,
+    ))
+
+    with open(archive_path, 'w') as archive:
+
+        # construct the pxz command to compress data
+        pxz_command = ['pxz', '--compress']
+        if threads is not None:
+            pxz_command.append('-T {threads}'.format(threads=threads))
+
+        pxz = subprocess.Popen(pxz_command, stdin=subprocess.PIPE, stdout=archive)
+
+        with tarfile.open(fileobj=pxz.stdin, mode='w|') as tar:
+
+            temp_dir = tempfile.mkdtemp()
+
+            # add metadata
+            try:
+                schema_seq_path = os.path.join(temp_dir, "SCHEMA_SEQUENCE")
+                with open(schema_seq_path, "w") as f:
+                    f.write(str(db.SCHEMA_VERSION))
+                tar.add(schema_seq_path,
+                        arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
+                timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
+                with open(timestamp_path, "w") as f:
+                    f.write(dump_time.isoformat(" "))
+                tar.add(timestamp_path,
+                        arcname=os.path.join(archive_name, "TIMESTAMP"))
+                tar.add(DUMP_LICENSE_FILE_PATH,
+                        arcname=os.path.join(archive_name, "COPYING"))
+            except IOError as e:
+                logger.error('IOError while adding dump metadata...')
+                raise
+            except Exception as e:
+                logger.error('Exception while adding dump metadata: %s', str(e))
+                raise
+
+            # copy tables to archive_tables_dir and then add it to the archive
+            archive_tables_dir = os.path.join(temp_dir, 'data')
+            create_path(archive_tables_dir)
+            with db.engine.connect() as connection:
+                with connection.begin() as transaction:
+                    cursor = connection.connection.cursor()
+                    for table in TABLES:
+                        try:
+                            with open(os.path.join(archive_tables_dir, table), 'w') as f:
+                                cursor.copy_to(f, '(SELECT * FROM {table})'.format(table=table))
+                        except IOError as e:
+                            logger.error('IOError while copying table %s', table)
+                            raise
+                        except Exception as e:
+                            logger.error('Error while copying table %s: %s', table, str(e))
+                            raise
+                    transaction.rollback()
+
+            tar.add(archive_tables_dir, arcname=os.path.join(archive_name, 'data'))
+            shutil.rmtree(temp_dir)
+
+        pxz.stdin.close()
+
+    return archive_path

--- a/messybrainz/db/dump_manager.py
+++ b/messybrainz/db/dump_manager.py
@@ -42,8 +42,12 @@ cli = click.Group()
 @cli.command()
 @click.option('--location', '-l', default=os.path.join(os.getcwd(), 'messybrainz-export'))
 @click.option('--threads', '-t', type=int)
-def create(location, threads):
-    """ TODO
+def create(location, threads=None):
+    """ Create a MessyBrainz data dump
+
+        Args:
+            location (str): path to the directory where the dump should be made
+            threads (int): the number of threads to be used while compression, 1 if not specified
     """
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     logger.info('Beginning data dump...')

--- a/messybrainz/db/dump_manager.py
+++ b/messybrainz/db/dump_manager.py
@@ -27,9 +27,9 @@ import os
 
 from messybrainz import db
 
-import default_config as config
+import messybrainz.default_config as config
 try:
-    import custom_config as config
+    import messybrainz.custom_config as config
 except ImportError:
     pass
 

--- a/messybrainz/db/dump_manager.py
+++ b/messybrainz/db/dump_manager.py
@@ -24,7 +24,9 @@ import click
 import logging
 import messybrainz.db.dump as db_dump
 import os
+import time
 
+from datetime import datetime
 from messybrainz import db
 
 import messybrainz.default_config as config
@@ -51,11 +53,21 @@ def create(location, threads=None):
     """
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     logger.info('Beginning data dump...')
+    dump_time = datetime.today()
     try:
-        dump_path = db_dump.dump_db(location, threads)
+        dump_path = db_dump.dump_db(location, threads, dump_time)
     except IOError as e:
         logger.error('IOError while dumping MessyBrainz database: %s', str(e))
         raise
+
+    while True:
+        try:
+            db_dump.add_dump_entry(dump_time.strftime('%s'))
+            break
+        except Exception as e:
+            logger.error('Error while adding new dump entry: %s', str(e))
+            time.sleep(3)
+
     logger.info('Data dump created at %s!', dump_path)
 
 

--- a/messybrainz/db/dump_manager.py
+++ b/messybrainz/db/dump_manager.py
@@ -1,0 +1,59 @@
+""" This module contains a click group with commands to
+create and import postgres data dumps.
+"""
+
+# messybrainz-server - Server for the MessyBrainz project
+#
+# Copyright (C) 2017 MetaBrainz Foundation Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version. #
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA)
+
+
+import click
+import logging
+import messybrainz.db.dump as db_dump
+import os
+
+from messybrainz import db
+
+import default_config as config
+try:
+    import custom_config as config
+except ImportError:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+cli = click.Group()
+
+
+@cli.command()
+@click.option('--location', '-l', default=os.path.join(os.getcwd(), 'messybrainz-export'))
+@click.option('--threads', '-t', type=int)
+def create(location, threads):
+    """ TODO
+    """
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    logger.info('Beginning data dump...')
+    try:
+        dump_path = db_dump.dump_db(location, threads)
+    except IOError as e:
+        logger.error('IOError while dumping MessyBrainz database: %s', str(e))
+        raise
+    logger.info('Data dump created at %s!', dump_path)
+
+
+if __name__ == '__main__':
+    cli()

--- a/messybrainz/db/licenses/COPYING-PublicDomain
+++ b/messybrainz/db/licenses/COPYING-PublicDomain
@@ -1,0 +1,105 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work
+of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work
+for the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without
+fear of later claims of infringement build upon, modify, incorporate in
+other works, reuse and redistribute as freely as possible in any form
+whatsoever and for any purposes, including without limitation commercial
+purposes. These owners may contribute to the Commons to promote the
+ideal of a free culture and the further production of creative, cultural
+and scientific works, or to gain reputation or greater distribution for
+their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or
+she is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under
+its terms, with knowledge of his or her Copyright and Related Rights in
+the Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may
+be protected by copyright and related or neighboring rights ("Copyright
+and Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+the right to reproduce, adapt, distribute, perform, display, communicate,
+and translate a Work; moral rights retained by the original author(s)
+and/or performer(s); publicity and privacy rights pertaining to a person's
+image or likeness depicted in a Work; rights protecting against unfair
+competition in regards to a Work, subject to the limitations in paragraph
+4(a), below; rights protecting the extraction, dissemination, use and
+reuse of data in a Work; database rights (such as those arising under
+Directive 96/9/EC of the European Parliament and of the Council of 11
+March 1996 on the legal protection of databases, and under any national
+implementation thereof, including any amended or successor version of
+such directive); and other similar, equivalent or corresponding rights
+throughout the world based on applicable law or treaty, and any national
+implementations thereof.  2. Waiver. To the greatest extent permitted by,
+but not in contravention of, applicable law, Affirmer hereby overtly,
+fully, permanently, irrevocably and unconditionally waives, abandons,
+and surrenders all of Affirmer's Copyright and Related Rights and
+associated claims and causes of action, whether now known or unknown
+(including existing as well as future claims and causes of action), in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions),
+(iii) in any current or future medium and for any number of copies, and
+(iv) for any purpose whatsoever, including without limitation commercial,
+advertising or promotional purposes (the "Waiver"). Affirmer makes the
+Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such
+Waiver shall not be subject to revocation, rescission, cancellation,
+termination, or any other legal or equitable action to disrupt the quiet
+enjoyment of the Work by the public as contemplated by Affirmer's express
+Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright
+and Related Rights in the Work (i) in all territories worldwide, (ii)
+for the maximum duration provided by applicable law or treaty (including
+future time extensions), (iii) in any current or future medium and for
+any number of copies, and (iv) for any purpose whatsoever, including
+without limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law,
+such partial invalidity or ineffectiveness shall not invalidate the
+remainder of the License, and in such case Affirmer hereby affirms that
+he or she will not (i) exercise any of his or her remaining Copyright
+and Related Rights in the Work or (ii) assert any associated claims and
+causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+No trademark or patent rights held by Affirmer are waived, abandoned,
+surrendered, licensed or otherwise affected by this document.  Affirmer
+offers the Work as-is and makes no representations or warranties of any
+kind concerning the Work, express, implied, statutory or otherwise,
+including without limitation warranties of title, merchantability,
+fitness for a particular purpose, non infringement, or the absence of
+latent or other defects, accuracy, or the present or absence of errors,
+whether or not discoverable, all to the greatest extent permissible
+under applicable law.  Affirmer disclaims responsibility for clearing
+rights of other persons that may apply to the Work or any use thereof,
+including without limitation any person's Copyright and Related Rights
+in the Work. Further, Affirmer disclaims responsibility for obtaining
+any necessary consents, permissions or other rights required for any
+use of the Work.  Affirmer understands and acknowledges that Creative
+Commons is not a party to this document and has no duty or obligation
+with respect to this CC0 or use of the Work.

--- a/messybrainz/db/licenses/README.md
+++ b/messybrainz/db/licenses/README.md
@@ -1,0 +1,3 @@
+IMPORTANT: The license file in this directory is the text file that gets included into the data dumps.
+
+The CC0 license DOES NOT APPLY to the code in this repository.

--- a/messybrainz/db/tests/test_dump.py
+++ b/messybrainz/db/tests/test_dump.py
@@ -1,0 +1,44 @@
+""" This module contains data dump creation and import tests.
+"""
+
+# messybrainz-server - Server for the MessyBrainz project
+#
+# Copyright (C) 2017 MetaBrainz Foundation Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version. #
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA)
+
+import messybrainz.db as db
+import messybrainz.db.dump as db_dump
+import tempfile
+
+from messybrainz.testing import DatabaseTestCase
+
+
+class DumpTestCase(DatabaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.mkdtemp()
+
+
+    def tearDown(self):
+        super().tearDown()
+        shutil.rmtree(self.tempdir)
+
+
+    def test_create_dump(self):
+        archive = db_dump.dump_db(self.tempdir)
+        self.assertTrue(os.path.isfile(archive))
+
+

--- a/messybrainz/db/tests/test_dump.py
+++ b/messybrainz/db/tests/test_dump.py
@@ -20,7 +20,9 @@
 
 import messybrainz.db as db
 import messybrainz.db.dump as db_dump
+import os
 import tempfile
+import shutil
 
 from messybrainz.testing import DatabaseTestCase
 

--- a/messybrainz/db/tests/test_dump.py
+++ b/messybrainz/db/tests/test_dump.py
@@ -24,6 +24,7 @@ import os
 import tempfile
 import shutil
 
+from datetime import datetime
 from messybrainz.testing import DatabaseTestCase
 
 
@@ -44,3 +45,8 @@ class DumpTestCase(DatabaseTestCase):
         self.assertTrue(os.path.isfile(archive))
 
 
+    def test_add_dump_entry(self):
+        prev_dumps = db_dump.get_dump_entries()
+        db_dump.add_dump_entry(datetime.today().strftime('%s'))
+        now_dumps = db_dump.get_dump_entries()
+        self.assertEqual(len(now_dumps), len(prev_dumps) + 1)

--- a/messybrainz/db/utils.py
+++ b/messybrainz/db/utils.py
@@ -1,0 +1,12 @@
+import errno
+import os
+
+
+def create_path(path):
+    """Creates a directory structure if it doesn't exist yet."""
+    try:
+        os.makedirs(path)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise Exception("Failed to create directory structure %s. Error: %s" %
+                            (path, exception))


### PR DESCRIPTION
This is mostly code reused from LB. 

One thing to do would be adding a table to keep track of dumps (for future incremental dumps).

Also, did a small restructure by creating a `db` folder instead of just a single `db.py`. I took a look and I don't think it should cause any regressions but another look would be nice to have.