### PR TITLE
Use find_packages to list all packages to install in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import glob
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
 version = os.environ.get('RELEASE_VERSION', '99.0.0.dev0')
 
@@ -9,7 +9,7 @@ setup(
     version=version,
     author='MessyBrainz',
     author_email='support@metabrainz.org',
-    packages=['messybrainz'],
+    packages=find_packages(),
     scripts=[x for x in glob.glob('bin/*.py') if x != 'bin/__init__.py'],
     license='LICENSE.txt',
     description='python interface to the messybrainz database.',


### PR DESCRIPTION
The new db module wasn't getting installed by
`python setup.py install` because it wasn't specified here.

See erroring build here: https://travis-ci.org/metabrainz/listenbrainz-server/builds/390453290#L1319