### PR TITLE
LB-372: MessyBrainz: Create artist_credit clusters using artist MBIDs in database

### DIFF
--- a/admin/sql/create_functions.sql
+++ b/admin/sql/create_functions.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+-- Returns sorted UUID array
+CREATE OR REPLACE FUNCTION array_sort(uuid[])
+RETURNS uuid[] AS $sorted_array$
+DECLARE
+    sorted_array uuid[];
+BEGIN
+    SELECT ARRAY(SELECT unnest($1) ORDER BY 1) INTO sorted_array;
+    RETURN sorted_array;
+END
+$sorted_array$ LANGUAGE plpgsql;
+
+-- Returns an sorted UUID array for an input JSON array
+CREATE OR REPLACE FUNCTION convert_json_array_to_sorted_uuid_array(json)
+RETURNS uuid[] AS $converted_array$
+DECLARE 
+    converted_array uuid[];
+BEGIN
+    SELECT array_sort(array_agg(elements)::uuid[]) || ARRAY[]::uuid[] INTO converted_array 
+    FROM json_array_elements_text($1) elements;
+    RETURN converted_array;
+END 
+$converted_array$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -22,6 +22,12 @@ CREATE TABLE artist_credit_redirect (
 );
 ALTER TABLE artist_credit_redirect ADD CONSTRAINT artist_credit_redirect_uniq UNIQUE (artist_credit_cluster_id, artist_mbid);
 
+CREATE TABLE artist_credit_redirect_array (
+  artist_credit_cluster_id UUID NOT NULL, -- FK to artist_credit_cluster.cluster_id
+  artist_mbids_array       UUID[] NOT NULL
+);
+ALTER TABLE artist_credit_redirect_array ADD CONSTRAINT artist_credit_redirect_array_artist_mbids_array_uniq UNIQUE (artist_mbids_array);
+
 CREATE TABLE recording (
   id         SERIAL,
   gid        UUID    NOT NULL,

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -18,15 +18,9 @@ ALTER TABLE artist_credit_cluster ADD CONSTRAINT artist_credit_cluster_uniq UNIQ
 
 CREATE TABLE artist_credit_redirect (
   artist_credit_cluster_id UUID NOT NULL, -- FK to artist_credit_cluster.cluster_id
-  artist_mbid              UUID NOT NULL
-);
-ALTER TABLE artist_credit_redirect ADD CONSTRAINT artist_credit_redirect_uniq UNIQUE (artist_credit_cluster_id, artist_mbid);
-
-CREATE TABLE artist_credit_redirect_array (
-  artist_credit_cluster_id UUID NOT NULL, -- FK to artist_credit_cluster.cluster_id
   artist_mbids_array       UUID[] NOT NULL
 );
-ALTER TABLE artist_credit_redirect_array ADD CONSTRAINT artist_credit_redirect_array_artist_mbids_array_uniq UNIQUE (artist_mbids_array);
+ALTER TABLE artist_credit_redirect ADD CONSTRAINT artist_credit_redirect_artist_mbids_array_uniq UNIQUE (artist_mbids_array);
 
 CREATE TABLE recording (
   id         SERIAL,

--- a/admin/sql/drop_tables.sql
+++ b/admin/sql/drop_tables.sql
@@ -1,15 +1,16 @@
 BEGIN;
 
-DROP TABLE IF EXISTS recording              CASCADE;
-DROP TABLE IF EXISTS recording_json         CASCADE;
-DROP TABLE IF EXISTS artist_credit          CASCADE;
-DROP TABLE IF EXISTS release                CASCADE;
-DROP TABLE IF EXISTS recording_redirect     CASCADE;
-DROP TABLE IF EXISTS recording_cluster      CASCADE;
-DROP TABLE IF EXISTS artist_credit_cluster  CASCADE;
-DROP TABLE IF EXISTS artist_credit_redirect CASCADE;
-DROP TABLE IF EXISTS release_cluster        CASCADE;
-DROP TABLE IF EXISTS release_redirect       CASCADE;
-DROP TABLE IF EXISTS recording_artist_join  CASCADE;
+DROP TABLE IF EXISTS recording                    CASCADE;
+DROP TABLE IF EXISTS recording_json               CASCADE;
+DROP TABLE IF EXISTS artist_credit                CASCADE;
+DROP TABLE IF EXISTS release                      CASCADE;
+DROP TABLE IF EXISTS recording_redirect           CASCADE;
+DROP TABLE IF EXISTS recording_cluster            CASCADE;
+DROP TABLE IF EXISTS artist_credit_cluster        CASCADE;
+DROP TABLE IF EXISTS artist_credit_redirect       CASCADE;
+DROP TABLE IF EXISTS release_cluster              CASCADE;
+DROP TABLE IF EXISTS release_redirect             CASCADE;
+DROP TABLE IF EXISTS recording_artist_join        CASCADE;
+DROP TABLE IF EXISTS artist_credit_redirect_array CASCADE;
 
 COMMIT;

--- a/admin/sql/drop_tables.sql
+++ b/admin/sql/drop_tables.sql
@@ -11,6 +11,5 @@ DROP TABLE IF EXISTS artist_credit_redirect       CASCADE;
 DROP TABLE IF EXISTS release_cluster              CASCADE;
 DROP TABLE IF EXISTS release_redirect             CASCADE;
 DROP TABLE IF EXISTS recording_artist_join        CASCADE;
-DROP TABLE IF EXISTS artist_credit_redirect_array CASCADE;
 
 COMMIT;

--- a/admin/sql/drop_tables.sql
+++ b/admin/sql/drop_tables.sql
@@ -1,15 +1,15 @@
 BEGIN;
 
-DROP TABLE IF EXISTS recording                    CASCADE;
-DROP TABLE IF EXISTS recording_json               CASCADE;
 DROP TABLE IF EXISTS artist_credit                CASCADE;
-DROP TABLE IF EXISTS release                      CASCADE;
-DROP TABLE IF EXISTS recording_redirect           CASCADE;
-DROP TABLE IF EXISTS recording_cluster            CASCADE;
 DROP TABLE IF EXISTS artist_credit_cluster        CASCADE;
 DROP TABLE IF EXISTS artist_credit_redirect       CASCADE;
+DROP TABLE IF EXISTS recording                    CASCADE;
+DROP TABLE IF EXISTS recording_artist_join        CASCADE;
+DROP TABLE IF EXISTS recording_cluster            CASCADE;
+DROP TABLE IF EXISTS recording_json               CASCADE;
+DROP TABLE IF EXISTS recording_redirect           CASCADE;
+DROP TABLE IF EXISTS release                      CASCADE;
 DROP TABLE IF EXISTS release_cluster              CASCADE;
 DROP TABLE IF EXISTS release_redirect             CASCADE;
-DROP TABLE IF EXISTS recording_artist_join        CASCADE;
 
 COMMIT;

--- a/admin/sql/updates/2018-06-14-create-artist-credit-redirect-array-table.sql
+++ b/admin/sql/updates/2018-06-14-create-artist-credit-redirect-array-table.sql
@@ -1,9 +1,0 @@
-BEGIN;
-
-CREATE TABLE artist_credit_redirect_array (
-  artist_credit_cluster_id UUID NOT NULL, -- FK to artist_credit_cluster.cluster_id
-  artist_mbids_array       UUID[] NOT NULL
-);
-ALTER TABLE artist_credit_redirect_array ADD CONSTRAINT artist_credit_redirect_array_artist_mbids_array_uniq UNIQUE (artist_mbids_array);
-
-COMMIT;

--- a/admin/sql/updates/2018-06-14-create-artist-credit-redirect-array-table.sql
+++ b/admin/sql/updates/2018-06-14-create-artist-credit-redirect-array-table.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+CREATE TABLE artist_credit_redirect_array (
+  artist_credit_cluster_id UUID NOT NULL, -- FK to artist_credit_cluster.cluster_id
+  artist_mbids_array       UUID[] NOT NULL
+);
+ALTER TABLE artist_credit_redirect_array ADD CONSTRAINT artist_credit_redirect_array_artist_mbids_array_uniq UNIQUE (artist_mbids_array);
+
+COMMIT;

--- a/admin/sql/updates/2018-06-26-alter-table-artist-credit-redirect.sql
+++ b/admin/sql/updates/2018-06-26-alter-table-artist-credit-redirect.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE artist_credit_redirect DROP COLUMN artist_mbid;
+ALTER TABLE artist_credit_redirect ADD COLUMN artist_mbids_array UUID[] NOT NULL;
+
+COMMIT;

--- a/manage.py
+++ b/manage.py
@@ -192,11 +192,11 @@ def create_artist_credit_clusters_for_mbids(verbose=False):
         logging.debug("=" * 80)
         clusters_modified, clusters_add_to_redirect = create_artist_credit_clusters()
         logging.debug("=" * 80)
-        print("Clusters modified: {0}.".format(clusters_modified))
-        print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
-        print ("Done!")
+        logging.info("Clusters modified: {0}.".format(clusters_modified))
+        logging.info("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
+        logging.info("Done!")
     except Exception as error:
-        print("While creating artist_credit clusters. An error occured: {0}".format(error))
+        logging.error("While creating artist_credit clusters. An error occured: {0}".format(error))
         raise
 
 
@@ -204,13 +204,14 @@ def create_artist_credit_clusters_for_mbids(verbose=False):
 def truncate_artist_credit_cluster_and_redirect():
     """Truncate artist_credit_cluster and artist_credit_redirect table."""
 
+    logging.basicConfig(format='%(message)s', level=logging.INFO)
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
         truncate_artist_credit_cluster_and_redirect_tables()
-        print("artist_credit_cluster and artist_credit_redirect table truncated.")
+        logging.info("artist_credit_cluster and artist_credit_redirect table truncated.")
 
     except Exception as error:
-        print("An error occured while truncating artist_credit_cluster"
+        logging.error("An error occured while truncating artist_credit_cluster"
             "and artist_credit_redirect table: {0}".format(error)
         )
         raise

--- a/manage.py
+++ b/manage.py
@@ -45,13 +45,13 @@ def init_db(force):
     """
     db.init_db_engine(config.POSTGRES_ADMIN_URI)
     if force:
-        res = db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'drop_db.sql'))
-        if not res:
+        exit_code = db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'drop_db.sql'))
+        if not exit_code:
             raise Exception('Failed to drop existing database and user! Exit code: %i' % exit_code)
 
     print('Creating user and a database...')
-    res = db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'create_db.sql'))
-    if not res:
+    exit_code = db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'create_db.sql'))
+    if not exit_code:
         raise Exception('Failed to create new database and user! Exit code: %i' % exit_code)
 
     print('Creating database extensions...')

--- a/manage.py
+++ b/manage.py
@@ -191,20 +191,16 @@ def create_artist_credit_clusters_for_mbids():
 
 @cli.command()
 def truncate_artist_credit_cluster_and_redirect():
-    """Truncate artist_credit_cluster, artist_credit_redirect, and
-       artist_credit_redirect_array tables.
-    """
+    """Truncate artist_credit_cluster and artist_credit_redirect table."""
 
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
         truncate_artist_credit_cluster_and_redirect_tables()
-        print("artist_credit_cluster, artist_credit_redirect, and"
-            "artist_credit_redirect_array tables truncated."
-        )
+        print("artist_credit_cluster and artist_credit_redirect table truncated.")
 
     except Exception as error:
-        print("An error occured while truncating artist_credit_cluster,"
-            "artist_credit_redirect, and artist_credit_redirect_array: {0}".format(error)
+        print("An error occured while truncating artist_credit_cluster"
+            "and artist_credit_redirect table: {0}".format(error)
         )
         raise
 

--- a/manage.py
+++ b/manage.py
@@ -10,6 +10,7 @@ from sqlalchemy import text
 import subprocess
 import os
 import click
+import logging
 
 import messybrainz.default_config as config
 try:
@@ -174,13 +175,23 @@ def truncate_recording_artist_join_table():
 
 
 @cli.command()
-def create_artist_credit_clusters_for_mbids():
+@click.option("--verbose", "-v", is_flag=True, help="Print debug information.")
+def create_artist_credit_clusters_for_mbids(verbose=False):
     """Creates clusters for artist_credits using artist MBIDs present in
        recording_json table.
     """
+
+    if verbose:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+    else:
+        logging.basicConfig(format='%(message)s', level=logging.INFO)
+    logging.info("Creating artist_credit clusters...")
+
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
+        logging.debug("=" * 80)
         clusters_modified, clusters_add_to_redirect = create_artist_credit_clusters()
+        logging.debug("=" * 80)
         print("Clusters modified: {0}.".format(clusters_modified))
         print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
         print ("Done!")

--- a/manage.py
+++ b/manage.py
@@ -69,6 +69,9 @@ def init_db(force):
         print('Creating indexes...')
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_indexes.sql'))
 
+        print('Creating functions...')
+        db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_functions.sql'))
+
     print("Done!")
 
 
@@ -100,6 +103,7 @@ def init_test_db(force=False):
     db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_primary_keys.sql'))
     db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_foreign_keys.sql'))
     db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_indexes.sql'))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_functions.sql'))
 
     print("Done!")
 

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,8 @@
 from messybrainz import db
 from messybrainz.db.artist import truncate_recording_artist_join,\
-                                                fetch_and_store_artist_mbids_for_all_recording_mbids
+                                fetch_and_store_artist_mbids_for_all_recording_mbids,\
+                                create_artist_credit_clusters,\
+                                truncate_artist_credit_cluster_and_redirect_tables
 from messybrainz.webserver import create_app
 from brainzutils import musicbrainz_db
 from sqlalchemy import text
@@ -168,6 +170,42 @@ def truncate_recording_artist_join_table():
         print("Table recording_artist_join truncated.")
     except Exception as error:
         print("An error occured while truncating tables: {0}".format(error))
+        raise
+
+
+@cli.command()
+def create_artist_credit_clusters_for_mbids():
+    """Creates clusters for artist_credits using artist MBIDs present in
+       recording_json table.
+    """
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    try:
+        clusters_modified, clusters_add_to_redirect = create_artist_credit_clusters()
+        print("Clusters modified: {0}.".format(clusters_modified))
+        print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
+        print ("Done!")
+    except Exception as error:
+        print("While creating artist_credit clusters. An error occured: {0}".format(error))
+        raise
+
+
+@cli.command()
+def truncate_artist_credit_cluster_and_redirect():
+    """Truncate artist_credit_cluster, artist_credit_redirect, and
+       artist_credit_redirect_array tables.
+    """
+
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    try:
+        truncate_artist_credit_cluster_and_redirect_tables()
+        print("artist_credit_cluster, artist_credit_redirect, and"
+            "artist_credit_redirect_array tables truncated."
+        )
+
+    except Exception as error:
+        print("An error occured while truncating artist_credit_cluster,"
+            "artist_credit_redirect, and artist_credit_redirect_array: {0}".format(error)
+        )
         raise
 
 

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -376,8 +376,8 @@ def create_artist_credit_clusters_for_anomalies(connection):
     artist_credits_left = fetch_artist_credits_left_to_cluster(connection)
     for artist_credit_mbids in artist_credits_left:
         artist_gids = get_artist_gids_from_recording_json_using_mbids(connection, artist_credit_mbids)
-        for artist_gid in artist_gids:
-            cluster_id = get_cluster_id_using_msid(connection, artist_gid)
+        cluster_ids = {get_cluster_id_using_msid(connection, artist_gid) for artist_gid in artist_gids}
+        for cluster_id in cluster_ids:
             link_artist_mbids_to_artist_credit_cluster_id(connection, cluster_id, artist_credit_mbids)
             clusters_add_to_redirect += 1
 

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -103,7 +103,7 @@ def fetch_and_store_artist_mbids_for_all_recording_mbids():
         return num_recording_mbids_processed, num_recording_mbids_added
 
 
-def fetch_distinct_artist_credit_mbids(connection):
+def fetch_unclustered_distinct_artist_credit_mbids(connection):
     """Fetch all the distinct artist MBIDs we have in recording_json table
        but don't have their corresponding MSIDs in artist_credit_cluster table.
 
@@ -338,7 +338,7 @@ def create_artist_credit_clusters_without_considering_anomalies(connection):
     clusters_modified = 0
     clusters_add_to_redirect = 0
     with db.engine.begin() as connection:
-        distinct_artist_credit_mbids = fetch_distinct_artist_credit_mbids(connection)
+        distinct_artist_credit_mbids = fetch_unclustered_distinct_artist_credit_mbids(connection)
         for artist_credit_mbids in distinct_artist_credit_mbids:
             gids = fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_credit_mbids)
             if gids:

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -1,6 +1,7 @@
 
 import brainzutils.musicbrainz_db.recording as mb_recording
 import json
+import uuid
 
 from brainzutils import musicbrainz_db
 from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
@@ -102,3 +103,297 @@ def fetch_and_store_artist_mbids_for_all_recording_mbids():
                 pass
 
         return num_recording_mbids_processed, num_recording_mbids_added
+
+
+def fetch_distinct_artist_credit_mbids(connection):
+    """Fetch all the distinct artist MBIDs we have in recording_json table
+       but don't have their corresponding MSIDs in artist_credit_cluster table.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+
+    Returns:
+        artist_credit_mbids(list): List of artist MBIDs.
+    """
+
+    # convert_json_array_to_sorted_uuid_array is a custom function for implementation
+    # details check admin/sql/create_functions.sql
+    result = connection.execute(text("""
+        SELECT DISTINCT convert_json_array_to_sorted_uuid_array(rj.data -> 'artist_mbids')
+                   FROM recording_json AS rj
+                   JOIN recording AS r
+                     ON r.data = rj.id
+              LEFT JOIN artist_credit_cluster AS acc
+                     ON r.artist = acc.artist_credit_gid
+                  WHERE rj.data ->> 'artist_mbids' IS NOT NULL
+                    AND acc.artist_credit_gid IS NULL
+    """))
+
+    return [artist_credit_mbids[0] for artist_credit_mbids in result]
+
+
+def link_artist_mbids_to_artist_credit_cluster_id(connection, cluster_id, artist_credit_mbids):
+    """Links the artist mbids to the cluster_id.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        cluster_id: the gid which represents the cluster.
+        artist_credit_mbids (list): list of artist MBIDs for the cluster.
+    """
+
+    connection.execute(text("""
+        INSERT INTO artist_credit_redirect_array (artist_credit_cluster_id, artist_mbids_array)
+             VALUES (:cluster_id, array_sort(:artist_credit_mbids))
+    """), {
+        "cluster_id": cluster_id,
+        "artist_credit_mbids": artist_credit_mbids,
+    })
+
+    values = [{"cluster_id": cluster_id, "mbid": mbid} for mbid in artist_credit_mbids]
+
+    connection.execute(text("""
+        INSERT INTO artist_credit_redirect (artist_credit_cluster_id, artist_mbid)
+             VALUES (:cluster_id, :mbid)
+    """), values
+    )
+
+
+def truncate_artist_credit_cluster_and_redirect_tables():
+    """Truncates artis_credit_cluster, artist_credit_redirect, and
+       artist_credit_redirect_array tables.
+    """
+
+    with db.engine.begin() as connection:
+        connection.execute(text("""TRUNCATE TABLE artist_credit_cluster"""))
+        connection.execute(text("""TRUNCATE TABLE artist_credit_redirect"""))
+        connection.execute(text("""TRUNCATE TABLE artist_credit_redirect_array"""))
+
+
+def insert_artist_credit_cluster(connection, cluster_id, artist_credit_gids):
+    """Creates a cluster with given cluster_id in the artist_credit_cluster table.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        cluster_id (UUID): the artist MSID which will represent the cluster.
+        artist_credit_gids (list): the list of MSIDs which will form a cluster.
+    """
+
+    values = [
+        {"cluster_id": cluster_id, "artist_credit_gid": artist_credit_gid} for artist_credit_gid in artist_credit_gids
+    ]
+
+    connection.execute(text("""
+        INSERT INTO artist_credit_cluster (cluster_id, artist_credit_gid, updated)
+             VALUES (:cluster_id, :artist_credit_gid, now())
+    """), values
+    )
+
+
+def fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_credit_mbids):
+    """Fetches the gids corresponding to an artist_mbid that are
+       not present in artist_credit_cluster table.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        artist_credit_mbids (list): a list of sorted artist MBIDs for which
+                                      gids are to be fetched.
+
+    Returns:
+        gids(list): List of gids.
+    """
+
+    # convert_json_array_to_sorted_uuid_array is a custom function for implementation
+    # details check admin/sql/create_functions.sql
+    gids = connection.execute(text("""
+        SELECT DISTINCT r.artist
+                   FROM recording_json AS rj
+                   JOIN recording AS r
+                     ON rj.id = r.data
+              LEFT JOIN artist_credit_cluster AS acc
+                     ON r.artist = acc.artist_credit_gid
+                  WHERE :artist_credit_mbids = convert_json_array_to_sorted_uuid_array(rj.data -> 'artist_mbids')
+                    AND acc.artist_credit_gid IS NULL
+    """), {
+        "artist_credit_mbids": artist_credit_mbids,
+    })
+
+    return [gid[0] for gid in gids]
+
+
+def get_artist_cluster_id_using_artist_mbids(connection, artist_credit_mbids):
+    """Returns the artist_credit_cluster_id that corresponds
+       to the given artist MBIDs.
+    """
+
+    # array_sort is a custom function for implementation
+    # details check admin/sql/create_functions.sql
+    gid = connection.execute(text("""
+        SELECT artist_credit_cluster_id
+          FROM artist_credit_redirect_array
+         WHERE artist_mbids_array = array_sort(:artist_credit_mbids)
+    """), {
+        "artist_credit_mbids": artist_credit_mbids,
+    })
+
+    if gid.rowcount:
+        return gid.fetchone()[0]
+    return None
+
+
+def fetch_artist_credits_left_to_cluster(connection):
+    """ Returns array of artist_mbids for the artist MBIDs that
+        were not clustered after executing the first phase of clustering.
+        These are anomalies.
+    """
+
+    # convert_json_array_to_sorted_uuid_array is a custom function for implementation
+    # details check admin/sql/create_functions.sql
+    result = connection.execute(text("""
+        SELECT DISTINCT convert_json_array_to_sorted_uuid_array(rj.data -> 'artist_mbids')
+                   FROM recording as r
+                   JOIN recording_json AS rj
+                     ON r.data = rj.id
+              LEFT JOIN artist_credit_redirect_array AS acra
+                     ON convert_json_array_to_sorted_uuid_array(rj.data -> 'artist_mbids') = acra.artist_mbids_array
+                  WHERE rj.data ->> 'artist_mbids' IS NOT NULL
+                    AND acra.artist_mbids_array IS NULL
+    """))
+
+    return [r[0] for r in result]
+
+
+def get_cluster_id_using_msid(connection, msid):
+    """ Gets the cluster ID for a given MSID.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        msid(UUID): an artist_credit gid for which cluster_id is to be fetched.
+
+    Returns:
+        cluster_id(UUID): cluster_id for the queried MSID if found. Else None is returned.
+    """
+
+    result = connection.execute(text("""
+        SELECT DISTINCT cluster_id
+                   FROM artist_credit_cluster
+                  WHERE artist_credit_gid = :msid
+    """), {
+        "msid": msid
+    })
+
+    if result.rowcount:
+        return result.fetchone()[0]
+    return None
+
+
+def get_artist_gids_from_recording_json_using_mbids(connection, artist_mbids):
+    """Returns artist MSIDs using a list of artist MBIDs.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        artist_mbids (list): a list of artist MBIDs for which gids are to be fetched.
+
+    Returns:
+        gids(list): list of artist gids for a given array of artist MBIDs.
+    """
+
+    # convert_json_array_to_sorted_uuid_array is a custom function for implementation
+    # details check admin/sql/create_functions.sql
+    result = connection.execute(text("""
+        SELECT DISTINCT r.artist
+                   FROM recording AS r
+                   JOIN recording_json AS rj
+                     ON r.data = rj.id
+                  WHERE array_sort(:artist_mbids) = convert_json_array_to_sorted_uuid_array(rj.data -> 'artist_mbids')
+    """), {
+        "artist_mbids": artist_mbids,
+    })
+
+    return [artist_gid[0] for artist_gid in result]
+
+
+def get_artist_mbids_using_msid(connection, artist_msid):
+    """Returns a list of list of artist MBIDs that corresponds
+       to the given artist MSID.
+    """
+
+    cluster_id = get_cluster_id_using_msid(connection, artist_msid)
+    # array_sort is a custom function for implementation
+    # details check admin/sql/create_functions.sql
+    mbids = connection.execute(text("""
+        SELECT artist_mbids_array
+          FROM artist_credit_redirect_array
+         WHERE artist_credit_cluster_id = :cluster_id
+    """), {
+        "cluster_id": cluster_id,
+    })
+
+    if mbids.rowcount:
+        return [mbid[0] for mbid in mbids]
+
+    return None
+
+
+def create_artist_credit_clusters_without_considering_anomalies(connection):
+    """Creates cluster for artist_credit without considering anamolies.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries.
+
+    Returns:
+        clusters_modified (int): number of clusters modified.
+        clusters_add_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    clusters_modified = 0
+    clusters_add_to_redirect = 0
+    with db.engine.begin() as connection:
+        distinct_artist_credit_mbids = fetch_distinct_artist_credit_mbids(connection)
+        for artist_credit_mbids in distinct_artist_credit_mbids:
+            gids = fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_credit_mbids)
+            if gids:
+                cluster_id = get_artist_cluster_id_using_artist_mbids(connection, artist_credit_mbids)
+                if not cluster_id:
+                    cluster_id = gids[0]
+                    link_artist_mbids_to_artist_credit_cluster_id(connection, cluster_id, artist_credit_mbids)
+                    clusters_add_to_redirect +=1
+                insert_artist_credit_cluster(connection, cluster_id, gids)
+                clusters_modified += 1
+    return clusters_modified, clusters_add_to_redirect
+
+
+def create_artist_credit_clusters_for_anomalies(connection):
+    """Creates artist_credit clusters for the anomalies.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+
+    Returns:
+        clusters_add_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    clusters_add_to_redirect = 0
+    artist_credits_left = fetch_artist_credits_left_to_cluster(connection)
+    for artist_credit_mbids in artist_credits_left:
+        artist_gids = get_artist_gids_from_recording_json_using_mbids(connection, artist_credit_mbids)
+        for artist_gid in artist_gids:
+            cluster_id = get_cluster_id_using_msid(connection, artist_gid)
+            link_artist_mbids_to_artist_credit_cluster_id(connection, cluster_id, artist_credit_mbids)
+            clusters_add_to_redirect += 1
+
+    return clusters_add_to_redirect
+
+
+def create_artist_credit_clusters():
+    """Creates clusters for artist mbids present in the recording_json table.
+
+    Returns:
+        clusters_modified (int): number of clusters modified.
+        clusters_add_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    with db.engine.begin() as connection:
+        clusters_modified, clusters_add_to_redirect = create_artist_credit_clusters_without_considering_anomalies(connection)
+        clusters_add_to_redirect += create_artist_credit_clusters_for_anomalies(connection)
+
+    return clusters_modified, clusters_add_to_redirect

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -1,7 +1,5 @@
 
 import brainzutils.musicbrainz_db.recording as mb_recording
-import json
-import uuid
 
 from brainzutils import musicbrainz_db
 from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
@@ -232,7 +230,8 @@ def get_artist_cluster_id_using_artist_mbids(connection, artist_credit_mbids):
 def fetch_artist_credits_left_to_cluster(connection):
     """ Returns array of artist_mbids for the artist MBIDs that
         were not clustered after executing the first phase of clustering.
-        These are anomalies.
+        These are anomalies (A single MSID pointing to multiple MBIDs arrays
+        in artist_credit_redirect table).
     """
 
     # convert_json_array_to_sorted_uuid_array is a custom function for implementation
@@ -324,7 +323,8 @@ def get_artist_mbids_using_msid(connection, artist_msid):
 
 
 def create_artist_credit_clusters_without_considering_anomalies(connection):
-    """Creates cluster for artist_credit without considering anamolies.
+    """Creates cluster for artist_credit without considering anomalies (A single MSID
+       pointing to multiple MBIDs arrays in artist_credit_redirect table).
 
     Args:
         connection: the sqlalchemy db connection to be used to execute queries.
@@ -352,7 +352,8 @@ def create_artist_credit_clusters_without_considering_anomalies(connection):
 
 
 def create_artist_credit_clusters_for_anomalies(connection):
-    """Creates artist_credit clusters for the anomalies.
+    """Creates artist_credit clusters for the anomalies (A single MSID
+       pointing to multiple MBIDs arrays in artist_credit_redirect table).
 
     Args:
         connection: the sqlalchemy db connection to be used to execute queries

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -182,13 +182,14 @@ def fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_credit_mbi
 
     Args:
         connection: the sqlalchemy db connection to be used to execute queries
-        artist_credit_mbids (list): a list of sorted artist MBIDs for which
-                                      gids are to be fetched.
+        artist_credit_mbids (list): a list of artist MBIDs for which gids are to be fetched.
+                                    The list is first sorted and then query is done.
 
     Returns:
         gids(list): List of gids.
     """
 
+    artist_credit_mbids.sort()
     # convert_json_array_to_sorted_uuid_array is a custom function for implementation
     # details check admin/sql/create_functions.sql
     gids = connection.execute(text("""

--- a/messybrainz/db/common.py
+++ b/messybrainz/db/common.py
@@ -1,0 +1,107 @@
+from messybrainz import db
+
+
+def create_entity_clusters(create_without_anomalies, create_with_anomalies):
+    """Takes two functions which create clusters for a given entity.
+
+    Args:
+        create_without_anomalies(function): this functions is responsible for creating
+        clusters without considering anomalies.
+        create_with_anomalies(function): this function will create clusters for the
+        anomalies (A single MSID pointing to multiple MBIDs in entity_redirect table).
+
+    Returns:
+        clusters_modified (int): number of clusters modified.
+        clusters_added_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    clusters_modified = 0
+    clusters_added_to_redirect = 0
+
+    with db.engine.connect() as connection:
+        clusters_modified, clusters_added_to_redirect = create_without_anomalies(connection)
+        clusters_added_to_redirect += create_with_anomalies(connection)
+
+    return clusters_modified, clusters_added_to_redirect
+
+
+def create_entity_clusters_for_anomalies(connection,
+                                        fetch_entities_left_to_cluster,
+                                        get_entity_gids_from_recording_json_using_mbids,
+                                        get_cluster_id_using_msid,
+                                        link_entity_mbid_to_entity_cluster_id):
+    """Creates entity clusters for the anomalies (A single MSID pointing
+       to multiple MBIDs in entity_redirect table).
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        fetch_entities_left_to_cluster(function): Returns mbids for the entity MBIDs that
+                                                were not clustered after executing the
+                                                first phase of clustering (clustering without
+                                                considering anomalies). These are anomalies
+                                                (A single MSID pointing to multiple MBIDs in
+                                                entity_redirect table).
+        get_entity_gids_from_recording_json_using_mbids(function): Returns entity MSIDs using
+                                                                an entity MBID.
+        get_cluster_id_using_msid(function): Gets the cluster ID for a given MSID.
+        link_entity_mbid_to_entity_cluster_id(function): Links the entity mbid to the cluster_id.
+
+    Returns:
+        clusters_add_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    clusters_add_to_redirect = 0
+    entities_left = fetch_entities_left_to_cluster(connection)
+    for entity_mbid in entities_left:
+        entity_gids = get_entity_gids_from_recording_json_using_mbids(connection, entity_mbid)
+        cluster_ids = {get_cluster_id_using_msid(connection, entity_gid) for entity_gid in entity_gids}
+        for cluster_id in cluster_ids:
+            link_entity_mbid_to_entity_cluster_id(connection, cluster_id, entity_mbid)
+            clusters_add_to_redirect += 1
+
+    return clusters_add_to_redirect
+
+
+def create_entity_clusters_without_considering_anomalies(connection,
+                                                        fetch_unclustered_entity_mbids,
+                                                        fetch_unclustered_gids_for_entity_mbids,
+                                                        get_entity_cluster_id_using_entity_mbids,
+                                                        link_entity_mbids_to_entity_cluster_id,
+                                                        insert_entity_cluster):
+    """Creates cluster for entity without considering anomalies (A single MSID pointing
+       to multiple MBIDs in entity_redirect table).
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries.
+        fetch_unclustered_entity_mbids (function): Fetch all the distinct entity
+                                                MBIDs we have in recording_json table
+                                                but don't have their corresponding MSIDs
+                                                in entity_cluster table.
+        fetch_unclustered_gids_for_entity_mbids (function): Fetches the gids corresponding
+                                                        to an entity_mbid that are not present
+                                                        in entity_cluster table.
+        get_entity_cluster_id_using_entity_mbids (function): Returns the entity_cluster_id
+                                                            that corresponds to the given entity MBID.
+        link_entity_mbids_to_entity_cluster_id (function): Links the entity mbid to the cluster_id.
+        insert_entity_cluster (function): Creates a cluster with given cluster_id in the
+                                        entity_cluster table.
+
+    Returns:
+        clusters_modified (int): number of clusters modified.
+        clusters_added_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    clusters_modified = 0
+    clusters_added_to_redirect = 0
+    distinct_entity_mbids = fetch_unclustered_entity_mbids(connection)
+    for entity_mbids in distinct_entity_mbids:
+        gids = fetch_unclustered_gids_for_entity_mbids(connection, entity_mbids)
+        if gids:
+            cluster_id = get_entity_cluster_id_using_entity_mbids(connection, entity_mbids)
+            if not cluster_id:
+                cluster_id = gids[0]
+                link_entity_mbids_to_entity_cluster_id(connection, cluster_id, entity_mbids)
+                clusters_added_to_redirect +=1
+            insert_entity_cluster(connection, cluster_id, gids)
+            clusters_modified += 1
+    return clusters_modified, clusters_added_to_redirect

--- a/messybrainz/db/testing.py
+++ b/messybrainz/db/testing.py
@@ -57,6 +57,7 @@ class DatabaseTestCase(unittest.TestCase):
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_primary_keys.sql'))
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_foreign_keys.sql'))
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_indexes.sql'))
+        db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_functions.sql'))
 
 
     def drop_tables(self):

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -169,7 +169,7 @@ class ArtistTestCase(DatabaseTestCase):
             self.assertSetEqual(set(artist_mbids), set(artist_mbids_fetched[3]))
 
 
-    def test_fetch_distinct_artist_credit_mbids(self):
+    def test_fetch_unclustered_distinct_artist_credit_mbids(self):
         """Tests if artist_credit MBIDs are fetched correctly."""
 
         msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
@@ -193,12 +193,12 @@ class ArtistTestCase(DatabaseTestCase):
         }
 
         with db.engine.begin() as connection:
-            artist_credit_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            artist_credit_mbids = artist.fetch_unclustered_distinct_artist_credit_mbids(connection)
             artist_credit_mbids = {tuple(artist_mbids) for artist_mbids in artist_credit_mbids}
             self.assertSetEqual(artist_mbids_submitted, artist_credit_mbids)
 
             artist.create_artist_credit_clusters()
-            artist_credit_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            artist_credit_mbids = artist.fetch_unclustered_distinct_artist_credit_mbids(connection)
             self.assertListEqual(artist_credit_mbids, [])
 
             recording_1 = {
@@ -208,7 +208,7 @@ class ArtistTestCase(DatabaseTestCase):
                 "artist_mbids": ["ff748426-8873-4725-bdc7-c2b18b510d41"],
             }
             submit_listens([recording_1])
-            artist_credit_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            artist_credit_mbids = artist.fetch_unclustered_distinct_artist_credit_mbids(connection)
             self.assertEqual(len(artist_credit_mbids), 1)
             self.assertListEqual([[UUID("ff748426-8873-4725-bdc7-c2b18b510d41")]], artist_credit_mbids)
 
@@ -227,7 +227,7 @@ class ArtistTestCase(DatabaseTestCase):
         submit_listens([recording_1])
 
         with db.engine.begin() as connection:
-            artist_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            artist_mbids = artist.fetch_unclustered_distinct_artist_credit_mbids(connection)
             gids = artist.fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_mbids[0])
             artist.link_artist_mbids_to_artist_credit_cluster_id(connection, gids[0], artist_mbids[0])
             cluster_id = artist.get_artist_cluster_id_using_artist_mbids(connection, artist_mbids[0])
@@ -256,7 +256,7 @@ class ArtistTestCase(DatabaseTestCase):
         submit_listens([recording_1, recording_2])
 
         with db.engine.begin() as connection:
-            artist_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            artist_mbids = artist.fetch_unclustered_distinct_artist_credit_mbids(connection)
             gids = artist.fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_mbids[0])
             self.assertEqual(len(gids), 2)
             artist.insert_artist_credit_cluster(connection, gids[0], gids)

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -215,7 +215,7 @@ class ArtistTestCase(DatabaseTestCase):
 
     def test_link_artist_mbids_to_artist_credit_cluster_id(self):
         """Tests if artist MBIDs are linked to correctly. Links are created in
-           artist_credit_redirect and artist_credit_redirect_array tables.
+           artist_credit_redirect table.
         """
 
         recording_1 = {

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -1,3 +1,4 @@
+from messybrainz import data
 from messybrainz import db
 from messybrainz import submit_listens_and_sing_me_a_sweet_song as submit_listens
 from messybrainz.db import artist
@@ -21,9 +22,21 @@ class ArtistTestCase(DatabaseTestCase):
             messy_dict = {
                 'artist': recording['artist'],
                 'title': recording['title'],
-                'recording_mbid': recording['recording_mbid'],
             }
+            if 'release' in recording:
+                messy_dict['release'] = recording['release']
+            if 'artist_mbids' in recording:
+                messy_dict['artist_mbids'] = recording['artist_mbids']
+            if 'release_mbid' in recording:
+                messy_dict['release_mbid'] = recording['release_mbid']
+            if 'recording_mbid' in recording:
+                messy_dict['recording_mbid'] = recording['recording_mbid']
+            if 'track_number' in recording:
+                messy_dict['track_number'] = recording['track_number']
+            if 'spotify_id' in recording:
+                messy_dict['spotify_id'] = recording['spotify_id']
             msb_listens.append(messy_dict)
+
         return msb_listens
 
 
@@ -154,3 +167,433 @@ class ArtistTestCase(DatabaseTestCase):
             artist.fetch_and_store_artist_mbids_for_all_recording_mbids()
             artist_mbids = artist.get_artist_mbids_for_recording_mbid(connection, "9ed38583-437f-4186-8183-9c31ffa2c116")
             self.assertSetEqual(set(artist_mbids), set(artist_mbids_fetched[3]))
+
+
+    def test_fetch_distinct_artist_credit_mbids(self):
+        """Tests if artist_credit MBIDs are fetched correctly."""
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+        artist_mbids_submitted = [
+            ["859d0860-d480-4efd-970c-c05d5f1776b8", "f82bcf78-5b69-4622-a5ef-73800768d9ac"],
+            ["bc1b5c95-e6d6-46b5-957a-5e8908b02c1e"],
+            ["f82bcf78-5b69-4622-a5ef-73800768d9ac"],
+            ["5cfeec75-f6e2-439c-946d-5317334cdc6c"],
+            ["88a8d8a9-7c9b-4f7b-8700-7f0f7a503688"],
+            ["b49a9595-3576-44bb-8ac0-e26d3f5b42ff"],
+        ]
+
+        artist_mbids_submitted = [
+            [UUID(artist_mbid) for artist_mbid in artist_mbids]
+            for artist_mbids in artist_mbids_submitted
+        ]
+
+        artist_mbids_submitted = {
+            tuple(artist_mbids) for artist_mbids in artist_mbids_submitted
+        }
+
+        with db.engine.begin() as connection:
+            artist_credit_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            artist_credit_mbids = {tuple(artist_mbids) for artist_mbids in artist_credit_mbids}
+            self.assertSetEqual(artist_mbids_submitted, artist_credit_mbids)
+
+            artist.create_artist_credit_clusters()
+            artist_credit_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            self.assertListEqual(artist_credit_mbids, [])
+
+            recording_1 = {
+                "artist": "Memphis Minnie",
+                "title": "Banana Man Blues",
+                "recording_mbid": "e1efdbee-2904-437f-b0e2-dbb4906b86d2",
+                "artist_mbids": ["ff748426-8873-4725-bdc7-c2b18b510d41"],
+            }
+            submit_listens([recording_1])
+            artist_credit_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            self.assertEqual(len(artist_credit_mbids), 1)
+            self.assertListEqual([[UUID("ff748426-8873-4725-bdc7-c2b18b510d41")]], artist_credit_mbids)
+
+
+    def test_link_artist_mbids_to_artist_credit_cluster_id(self):
+        """Tests if artist MBIDs are linked to correctly. Links are created in
+           artist_credit_redirect and artist_credit_redirect_array tables.
+        """
+
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac","859d0860-d480-4efd-970c-c05d5f1776b8"],
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "title": "'03 Bonnie and Clyde",
+        }
+        submit_listens([recording_1])
+
+        with db.engine.begin() as connection:
+            artist_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            gids = artist.fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_mbids[0])
+            artist.link_artist_mbids_to_artist_credit_cluster_id(connection, gids[0], artist_mbids[0])
+            cluster_id = artist.get_artist_cluster_id_using_artist_mbids(connection, artist_mbids[0])
+            self.assertEqual(cluster_id, gids[0])
+
+
+    def test_insert_artist_credit_cluster(self):
+        """Tests if artist_credit cluster is stored correctly in artist_credit_cluster table."""
+
+        # recording_1 and recording_2 are different as join phrase in artist of recording_1
+        # is '&' and in recording_2 is 'and'.
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac","859d0860-d480-4efd-970c-c05d5f1776b8"],
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "title": "'03 Bonnie and Clyde",
+        }
+
+        recording_2 = {
+            "artist": "Jay‐Z and Beyoncé",
+            "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac","859d0860-d480-4efd-970c-c05d5f1776b8"],
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "title": "'03 Bonnie and Clyde",
+        }
+
+        submit_listens([recording_1, recording_2])
+
+        with db.engine.begin() as connection:
+            artist_mbids = artist.fetch_distinct_artist_credit_mbids(connection)
+            gids = artist.fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_mbids[0])
+            self.assertEqual(len(gids), 2)
+            artist.insert_artist_credit_cluster(connection, gids[0], gids)
+            gids = artist.fetch_unclustered_gids_for_artist_credit_mbids(connection, artist_mbids[0])
+            self.assertEqual(len(gids), 0)
+
+
+    def test_fetch_unclustered_gids_for_artist_credit_mbids(self):
+        """Tests if gids are fetched for an array of artist MBIDs correctly."""
+
+        # recording_1 and recording_2 are different as join phrase in artist of recording_1
+        # is '&' and in recording_2 is 'and'.
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac", "859d0860-d480-4efd-970c-c05d5f1776b8"],
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "title": "'03 Bonnie and Clyde",
+        }
+
+        recording_2 = {
+            "artist": "Jay‐Z and Beyoncé",
+            "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac", "859d0860-d480-4efd-970c-c05d5f1776b8"],
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "title": "'03 Bonnie and Clyde",
+        }
+
+        submit_listens([recording_1, recording_2])
+
+        with db.engine.begin() as connection:
+            # Order of MBIDs matter here. It must be sorted. In artist.create_artist_credit_clusters
+            # we get artist_credit_mbids from artist.fetch_distinct_artist_credit_mbids which returns
+            # sorted array of MBIDs, so there it does not matter.
+            gids = artist.fetch_unclustered_gids_for_artist_credit_mbids(connection, [
+                        UUID("859d0860-d480-4efd-970c-c05d5f1776b8"), UUID("f82bcf78-5b69-4622-a5ef-73800768d9ac")
+                    ])
+            gids_from_data = set([
+                UUID(data.get_artist_credit(connection, recording_1["artist"])),
+                UUID(data.get_artist_credit(connection, recording_2["artist"]))
+            ])
+            self.assertSetEqual(set(gids), gids_from_data)
+
+
+    def test_get_artist_cluster_id_using_artist_mbids(self):
+        """Tests if cluster_id is returned correctly using artist_mbids."""
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+
+        artist.create_artist_credit_clusters()
+        with db.engine.begin() as connection:
+            cluster_id = artist.get_artist_cluster_id_using_artist_mbids(connection, [
+                        UUID("859d0860-d480-4efd-970c-c05d5f1776b8"), UUID("f82bcf78-5b69-4622-a5ef-73800768d9ac")
+                    ])
+
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z & Beyoncé"))
+            cluster_id_from_data = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertEqual(cluster_id, cluster_id_from_data)
+
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z and Beyoncé"))
+            cluster_id_from_data = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertEqual(cluster_id, cluster_id_from_data)
+
+            cluster_id = artist.get_artist_cluster_id_using_artist_mbids(connection, [
+                        UUID("88a8d8a9-7c9b-4f7b-8700-7f0f7a503688"),
+            ])
+
+            gid_from_data = UUID(data.get_artist_credit(connection, "James Morrison"))
+            cluster_id_from_data = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertEqual(cluster_id, cluster_id_from_data)
+
+
+    def test_fetch_artist_credits_left_to_cluster(self):
+        """Tests if artist_credits left to cluster after first
+           pass are correctly fetched.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+
+        with db.engine.begin() as connection:
+            artist.create_artist_credit_clusters_without_considering_anomalies(connection)
+            # In the data used from recordings_for_testing_artist_clusters
+            # the recordings for artist 'James Morrison' represents anomaly
+            # as two James Morrison exist with different artist MBIDs
+
+            artist_left = artist.fetch_artist_credits_left_to_cluster(connection)
+            self.assertEqual(len(artist_left), 1)
+
+            # 'James Morrison' with artist MBID '88a8d8a9-7c9b-4f7b-8700-7f0f7a503688'
+            # was clustered in the first phase.
+            self.assertListEqual(artist_left, [[UUID("b49a9595-3576-44bb-8ac0-e26d3f5b42ff")]])
+
+
+    def test_get_cluster_id_using_msid(self):
+        """Tests if cluster_id is correctly retrived using any MSID for the cluster."""
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+
+        artist.create_artist_credit_clusters()
+        with db.engine.begin() as connection:
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z & Beyoncé"))
+            cluster_id_1 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z and Beyoncé"))
+            cluster_id_2 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+
+    def test_get_artist_gids_from_recording_json_using_mbids(self):
+        """Tests if artist_gids are correctly fetched using a given list of artist MBIDs"""
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+
+        with db.engine.begin() as connection:
+            mbids = [
+                        UUID("859d0860-d480-4efd-970c-c05d5f1776b8"),
+                        UUID("f82bcf78-5b69-4622-a5ef-73800768d9ac"),
+                    ]
+            gids = set(artist.get_artist_gids_from_recording_json_using_mbids(connection, mbids))
+            gids_from_data = set([
+                UUID(data.get_artist_credit(connection, "Jay‐Z & Beyoncé")),
+                UUID(data.get_artist_credit(connection, "Jay‐Z and Beyoncé"))
+            ])
+
+            self.assertSetEqual(gids, gids_from_data)
+
+
+    def test_get_artist_mbids_using_msid(self):
+        """Test if artist_mbids are fetched correctly for given MSID"""
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+        artist.create_artist_credit_clusters()
+
+        with db.engine.begin() as connection:
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z & Beyoncé"))
+            artist_mbids_1 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z and Beyoncé"))
+            artist_mbids_2 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids_1, artist_mbids_2)
+
+
+    def test_create_artist_credit_clusters_without_considering_anomalies(self):
+        """Tests if clusters are created without considering anomalies are
+           are correctly formed.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+
+        with db.engine.begin() as connection:
+            clusters_modified, clusters_add_to_redirect = artist.create_artist_credit_clusters_without_considering_anomalies(connection)
+            self.assertEqual(clusters_modified, 5)
+            self.assertEqual(clusters_add_to_redirect, 5)
+
+            # 'Jay-Z & Beyonce' and 'Jay-Z and Beyonce' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z & Beyoncé"))
+            artist_mbids_1 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_1 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z and Beyoncé"))
+            artist_mbids_2 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_2 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids_1, artist_mbids_2)
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+            # 'Lil' Kim' and 'Lil Kim' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "Lil’ Kim"))
+            artist_mbids_1 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_1 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_artist_credit(connection, "Lil Kim"))
+            artist_mbids_2 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_2 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids_1, artist_mbids_2)
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+            # 'Jay-Z' and 'Jay_Z' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "JAY-Z"))
+            artist_mbids_1 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_1 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_artist_credit(connection, "JAY_Z"))
+            artist_mbids_2 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_2 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids_1, artist_mbids_2)
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+            # 'Syreeta' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "Syreeta"))
+            artist_mbids = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids, [[UUID("5cfeec75-f6e2-439c-946d-5317334cdc6c")]])
+
+            # 'James Morrison' with artist MBID '88a8d8a9-7c9b-4f7b-8700-7f0f7a503688'
+            # is clustered as before no artist_credit_gid exists with this artist_credit
+            # in artist_credit_cluster before this is inserted.
+            gid_from_data = UUID(data.get_artist_credit(connection, "James Morrison"))
+            artist_mbids = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids, [[UUID("88a8d8a9-7c9b-4f7b-8700-7f0f7a503688")]])
+
+
+    def test_create_artist_credit_clusters_for_anomalies(self):
+        """Tests if clusters are created correctly for the anomalies."""
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+
+        with db.engine.begin() as connection:
+            clusters_modified, clusters_add_to_redirect = artist.create_artist_credit_clusters_without_considering_anomalies(connection)
+            self.assertEqual(clusters_modified, 5)
+            self.assertEqual(clusters_add_to_redirect, 5)
+
+            # Before clustering anomalies
+            # 'James Morrison' with artist MBID '88a8d8a9-7c9b-4f7b-8700-7f0f7a503688'
+            # is clustered as before no artist_credit_gid exists with this artist_credit
+            # in artist_credit_cluster before this is inserted.
+            gid_from_data = UUID(data.get_artist_credit(connection, "James Morrison"))
+            artist_mbids = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids, [[UUID("88a8d8a9-7c9b-4f7b-8700-7f0f7a503688")]])
+
+            clusters_add_to_redirect = artist.create_artist_credit_clusters_for_anomalies(connection)
+            self.assertEqual(clusters_add_to_redirect, 1)
+
+            # After clustering anomalies
+            # 'James Morrison' with artist MBID 'b49a9595-3576-44bb-8ac0-e26d3f5b42ff'
+            # is clustered
+            gid_from_data = UUID(data.get_artist_credit(connection, "James Morrison"))
+            artist_mbids = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids, [
+                [UUID("88a8d8a9-7c9b-4f7b-8700-7f0f7a503688")], [UUID("b49a9595-3576-44bb-8ac0-e26d3f5b42ff")]
+            ])
+
+
+    def test_create_artist_credit_clusters(self):
+        """Tests if artist_credit clusters are correctly formed."""
+
+        msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
+        submit_listens(msb_listens)
+        clusters_modified, clusters_add_to_redirect = artist.create_artist_credit_clusters()
+        self.assertEqual(clusters_modified, 5)
+        self.assertEqual(clusters_add_to_redirect, 6)
+
+        with db.engine.begin() as connection:
+            # 'Jay-Z & Beyonce' and 'Jay-Z and Beyonce' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z & Beyoncé"))
+            artist_mbids_1 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_1 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_artist_credit(connection, "Jay‐Z and Beyoncé"))
+            artist_mbids_2 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_2 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids_1, artist_mbids_2)
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+            # 'Lil' Kim' and 'Lil Kim' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "Lil’ Kim"))
+            artist_mbids_1 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_1 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_artist_credit(connection, "Lil Kim"))
+            artist_mbids_2 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_2 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids_1, artist_mbids_2)
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+            # 'Jay-Z' and 'Jay_Z' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "JAY-Z"))
+            artist_mbids_1 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_1 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_artist_credit(connection, "JAY_Z"))
+            artist_mbids_2 = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            cluster_id_2 = artist.get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids_1, artist_mbids_2)
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+            # 'Syreeta' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "Syreeta"))
+            artist_mbids = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids, [[UUID("5cfeec75-f6e2-439c-946d-5317334cdc6c")]])
+
+            # 'James Morrison' with artist MBID '88a8d8a9-7c9b-4f7b-8700-7f0f7a503688'
+            # and 'James Morrison' with artist MBID 'b49a9595-3576-44bb-8ac0-e26d3f5b42ff'
+            # form a cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "James Morrison"))
+            artist_mbids = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids, [
+                [UUID("88a8d8a9-7c9b-4f7b-8700-7f0f7a503688")], [UUID("b49a9595-3576-44bb-8ac0-e26d3f5b42ff")]
+            ])
+
+            # Add new recordings and test again.
+            recordings = [
+                {
+                    "artist": "Consequence feat. Kanye West",
+                    "artist_mbids": ["164f0d73-1234-4e2c-8743-d77bf2191051", "c2e49f7a-cd6f-48ca-8596-b03614ea4fe8"],
+                    "recording_mbid": "589d375f-2f79-4841-b971-4d22d245241a",
+                    "title": "Getting Out the Game",
+                },
+                {
+                    "artist": "Jay‐Z and Beyoncé",
+                    "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac","859d0860-d480-4efd-970c-c05d5f1776b8"],
+                    "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+                    "title": "03 Bonnie and Clyde",
+                },
+                {
+                    "artist": "James Morrison",
+                    "artist_mbids": ["b29c0d07-99a3-478c-af62-26e0728dfd55"],
+                    "recording_mbid": "4daf8756-e1ed-469d-9b66-92af5ede7706",
+                    "title": "Miss Langford’s Reel / The Milestone at the Garden",
+                },
+                {
+                    "artist": "James Morrison",
+                    "artist_mbids": ["a3352eff-cde0-4f15-b44a-6f5c3e9cf079"],
+                    "recording_mbid": "3447878d-233a-46ad-b6a8-b754f922a7a4",
+                    "title": "Main in the Mirror (acoustic)",
+                },
+            ]
+
+            submit_listens(recordings)
+            clusters_modified, clusters_add_to_redirect = artist.create_artist_credit_clusters()
+
+            # Only one new pair added to artist_credit_cluster is 'Consequence feat. Kanye West'
+            self.assertEqual(clusters_modified, 1)
+
+            # Two new 'James Morrison' are added to redirect artist_credit_redirect table
+            # and 'Consequence feat. Kanye West' is also added to artist_credit_redirect table
+            self.assertEqual(clusters_add_to_redirect, 3)
+
+            # Four different 'James Morrison' exist in database
+            gid_from_data = UUID(data.get_artist_credit(connection, "James Morrison"))
+            artist_mbids = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids, [
+                [UUID("88a8d8a9-7c9b-4f7b-8700-7f0f7a503688")],
+                [UUID("b49a9595-3576-44bb-8ac0-e26d3f5b42ff")],
+                [UUID("b29c0d07-99a3-478c-af62-26e0728dfd55")],
+                [UUID("a3352eff-cde0-4f15-b44a-6f5c3e9cf079")],
+            ])
+
+            # 'Consequence feat. Kanye West' form one cluster
+            gid_from_data = UUID(data.get_artist_credit(connection, "Consequence feat. Kanye West"))
+            artist_mbids = artist.get_artist_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(artist_mbids, [
+                [UUID("164f0d73-1234-4e2c-8743-d77bf2191051"), UUID("c2e49f7a-cd6f-48ca-8596-b03614ea4fe8")]
+            ])

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -286,9 +286,6 @@ class ArtistTestCase(DatabaseTestCase):
         submit_listens([recording_1, recording_2])
 
         with db.engine.begin() as connection:
-            # Order of MBIDs matter here. It must be sorted. In artist.create_artist_credit_clusters
-            # we get artist_credit_mbids from artist.fetch_distinct_artist_credit_mbids which returns
-            # sorted array of MBIDs, so there it does not matter.
             gids = artist.fetch_unclustered_gids_for_artist_credit_mbids(connection, [
                         UUID("859d0860-d480-4efd-970c-c05d5f1776b8"), UUID("f82bcf78-5b69-4622-a5ef-73800768d9ac")
                     ])

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -214,7 +214,7 @@ class ArtistTestCase(DatabaseTestCase):
 
 
     def test_link_artist_mbids_to_artist_credit_cluster_id(self):
-        """Tests if artist MBIDs are linked to correctly. Links are created in
+        """Tests if artist MBIDs are linked to cluster correctly. Links are created in
            artist_credit_redirect table.
         """
 
@@ -402,7 +402,8 @@ class ArtistTestCase(DatabaseTestCase):
 
 
     def test_create_artist_credit_clusters_without_considering_anomalies(self):
-        """Tests if clusters are created without considering anomalies are
+        """Tests if clusters created without considering anomalies (A single
+           MSID pointing to multiple MBIDs arrays in artist_credit_redirect table)
            are correctly formed.
         """
 
@@ -458,7 +459,10 @@ class ArtistTestCase(DatabaseTestCase):
 
 
     def test_create_artist_credit_clusters_for_anomalies(self):
-        """Tests if clusters are created correctly for the anomalies."""
+        """Tests if clusters are created correctly for the anomalies
+           (A single MSID pointing to multiple MBIDs arrays in
+           artist_credit_redirect table).
+        """
 
         msb_listens = self._load_test_data("recordings_for_testing_artist_clusters.json")
         submit_listens(msb_listens)

--- a/messybrainz/testdata/recordings_for_testing_artist_clusters.json
+++ b/messybrainz/testdata/recordings_for_testing_artist_clusters.json
@@ -1,0 +1,63 @@
+[
+    {
+        "artist": "Jay‐Z & Beyoncé",
+        "title": "'03 Bonnie & Clyde"
+    },
+    {
+        "artist": "Big Sean feat. The‐Dream",
+        "title": "Live This Life"
+    },
+    {
+        "artist": "Jay‐Z & Beyoncé",
+        "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac","859d0860-d480-4efd-970c-c05d5f1776b8"],
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "title": "'03 Bonnie and Clyde"
+    },
+    {
+        "artist": "Jay‐Z and Beyoncé",
+        "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac","859d0860-d480-4efd-970c-c05d5f1776b8"],
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "title": "'03 Bonnie & Clyde"
+    },
+    {
+        "artist": "Lil’ Kim",
+        "artist_mbids": ["bc1b5c95-e6d6-46b5-957a-5e8908b02c1e"],
+        "recording_mbid": "6ba092ae-aaf7-4154-b987-9eb9d05f8616",
+        "title": "Don't Mess With Me"
+    },
+    {
+        "artist": "Lil Kim",
+        "artist_mbids": ["bc1b5c95-e6d6-46b5-957a-5e8908b02c1e"],
+        "recording_mbid": "6ba092ae-aaf7-4154-b987-9eb9d05f8616",
+        "title": "Don't Mess With Me"
+    },
+    {
+        "artist": "JAY-Z",
+        "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac"],
+        "recording_mbid": "cad174ad-d683-4858-a205-7bdc4175fff7",
+        "title": "Some People Hate"
+    },
+    {
+        "artist": "JAY_Z",
+        "artist_mbids": ["f82bcf78-5b69-4622-a5ef-73800768d9ac"],
+        "recording_mbid": "cad174ad-d683-4858-a205-7bdc4175fff7",
+        "title": "Some People Hate"
+    },
+    {
+        "artist": "Syreeta",
+        "artist_mbids": ["5cfeec75-f6e2-439c-946d-5317334cdc6c"],
+        "title": "She's Leaving Home"
+    },
+    {
+        "artist": "James Morrison",
+        "artist_mbids": ["88a8d8a9-7c9b-4f7b-8700-7f0f7a503688"],
+        "recording_mbid": "71fdb968-48c1-4406-a1f1-9dd2e9e37e0c",
+        "title": "6 Weeks"
+    },
+    {
+        "artist": "James Morrison",
+        "artist_mbids": ["b49a9595-3576-44bb-8ac0-e26d3f5b42ff"],
+        "recording_mbid": "181d63e7-5ed3-4c6c-9018-dad36128d7a7",
+        "title": "A Brush With Bunj"
+    }
+]


### PR DESCRIPTION
# Summary
This PR includes a script for creating artist_credit clusters.
* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
# Problem
We need to create clusters and associate MSIDs to MBIDs.
* JIRA ticket (_optional_): [LB-372](https://tickets.metabrainz.org/browse/LB-372)
# Solution
Add a script which will create clusters for artists that have artist MBIDs in recording_json table.
This is somewhat similar to what I've written in my [proposal](https://community.metabrainz.org/t/gsoc-2018-a-way-to-associate-listens-with-mbids/367667) 

### Additional things apart from the proposal:
1. New table artist_credit_redirect_array which stores artist MBIDs as arrays, and is represented by an artist_credit_cluster_id.
2. The clusters are created in 2 phases in phase-1 simple cases are handled and in phase-2 anomalies are handled.