### PR TITLE
LB-373: MessyBrainz: Create release clusters using release MBIDs in recording_json table

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -141,7 +141,7 @@ def truncate_recording_cluster_and_redirect():
 
 
 @cli.command()
-def fetch_and_store_artist_mbids(reset=False):
+def fetch_and_store_artist_mbids():
     """ Fetches artist MBIDs from the musicbrainz database for the recording MBIDs
         in the recording_json table submitted while submitting a listen. It fetches
         only the artist MBIDs for the recordings MBIDs which are not in recording_artist_join
@@ -177,7 +177,7 @@ def truncate_recording_artist_join_table():
 
 @cli.command()
 @click.option("--verbose", "-v", default=0, help="Print debug information for given verbose level(0,1,2).")
-def create_artist_credit_clusters_for_mbids(verbose=False):
+def create_artist_credit_clusters_for_mbids(verbose=0):
     """Creates clusters for artist_credits using artist MBIDs present in
        recording_json table.
     """
@@ -203,7 +203,7 @@ def create_artist_credit_clusters_for_mbids(verbose=False):
 
 @cli.command()
 @click.option("--verbose", "-v", default=0, help="Print debug information for given verbose level(0,1,2).")
-def create_release_clusters_for_mbids(verbose=False, detail=False):
+def create_release_clusters_for_mbids(verbose=0):
     """Creates clusters for release using release MBIDs present in
        recording_json table.
     """

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,7 @@ from messybrainz.db.artist import truncate_recording_artist_join,\
                                 fetch_and_store_artist_mbids_for_all_recording_mbids,\
                                 create_artist_credit_clusters,\
                                 truncate_artist_credit_cluster_and_redirect_tables
+from messybrainz.db import release
 from messybrainz.webserver import create_app
 from brainzutils import musicbrainz_db
 from sqlalchemy import text
@@ -197,6 +198,21 @@ def create_artist_credit_clusters_for_mbids(verbose=False):
         logging.info("Done!")
     except Exception as error:
         logging.error("While creating artist_credit clusters. An error occured: {0}".format(error))
+
+
+@cli.command()
+def create_release_clusters_for_mbids():
+    """Creates clusters for release using release MBIDs present in
+       recording_json table.
+    """
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    try:
+        clusters_modified, clusters_add_to_redirect = release.create_release_clusters()
+        print("Clusters modified: {0}.".format(clusters_modified))
+        print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
+        print ("Done!")
+    except Exception as error:
+        print("While creating release clusters. An error occured: {0}".format(error))
         raise
 
 
@@ -214,6 +230,17 @@ def truncate_artist_credit_cluster_and_redirect():
         logging.error("An error occured while truncating artist_credit_cluster"
             "and artist_credit_redirect table: {0}".format(error)
         )
+
+
+@cli.command()
+def truncate_release_cluster_and_redirect():
+    """Truncate release_cluster and release_redirect tables."""
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    try:
+        release.truncate_release_cluster_and_release_redirect_table()
+        print("release_cluster and release_redirect table truncated.")
+    except Exception as error:
+        print("An error occured while truncating release_cluster and release_redirect: {0}".format(error))
         raise
 
 

--- a/manage.py
+++ b/manage.py
@@ -176,49 +176,50 @@ def truncate_recording_artist_join_table():
 
 
 @cli.command()
-@click.option("--verbose", "-v", is_flag=True, help="Print debug information.")
+@click.option("--verbose", "-v", default=0, help="Print debug information for given verbose level(0,1,2).")
 def create_artist_credit_clusters_for_mbids(verbose=False):
     """Creates clusters for artist_credits using artist MBIDs present in
        recording_json table.
     """
 
-    if verbose:
-        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
-    else:
+    if verbose == 1:
         logging.basicConfig(format='%(message)s', level=logging.INFO)
-    logging.info("Creating artist_credit clusters...")
+    elif verbose == 2:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+
+    print("Creating artist_credit clusters...")
 
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
         logging.debug("=" * 80)
         clusters_modified, clusters_add_to_redirect = create_artist_credit_clusters()
         logging.debug("=" * 80)
-        logging.info("Clusters modified: {0}.".format(clusters_modified))
-        logging.info("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
-        logging.info("Done!")
+        print("Clusters modified: {0}.".format(clusters_modified))
+        print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
+        print("Done!")
     except Exception as error:
-        logging.error("While creating artist_credit clusters. An error occured: {0}".format(error))
+        print("While creating artist_credit clusters. An error occured: {0}".format(error))
 
 
 @cli.command()
-@click.option("--verbose", "-v", is_flag=True, help="Print debug information.")
-def create_release_clusters_for_mbids(verbose=False):
+@click.option("--verbose", "-v", default=0, help="Print debug information for given verbose level(0,1,2).")
+def create_release_clusters_for_mbids(verbose=False, detail=False):
     """Creates clusters for release using release MBIDs present in
        recording_json table.
     """
 
-    if verbose:
-        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
-    else:
+    if verbose == 1:
         logging.basicConfig(format='%(message)s', level=logging.INFO)
+    elif verbose == 2:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
 
-    logging.info("Creating release clusters...")
+    print("Creating release clusters...")
 
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
-        logging.debug("=" * 80)
+        logging.info("=" * 80)
         clusters_modified, clusters_add_to_redirect = release.create_release_clusters()
-        logging.debug("=" * 80)
+        logging.info("=" * 80)
         print("Clusters modified: {0}.".format(clusters_modified))
         print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
         print ("Done!")

--- a/manage.py
+++ b/manage.py
@@ -201,13 +201,24 @@ def create_artist_credit_clusters_for_mbids(verbose=False):
 
 
 @cli.command()
-def create_release_clusters_for_mbids():
+@click.option("--verbose", "-v", is_flag=True, help="Print debug information.")
+def create_release_clusters_for_mbids(verbose=False):
     """Creates clusters for release using release MBIDs present in
        recording_json table.
     """
+
+    if verbose:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+    else:
+        logging.basicConfig(format='%(message)s', level=logging.INFO)
+
+    logging.info("Creating release clusters...")
+
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
+        logging.debug("=" * 80)
         clusters_modified, clusters_add_to_redirect = release.create_release_clusters()
+        logging.debug("=" * 80)
         print("Clusters modified: {0}.".format(clusters_modified))
         print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
         print ("Done!")

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -323,6 +323,22 @@ def get_artist_mbids_using_msid(connection, artist_msid):
     return None
 
 
+def get_recordings_metadata_using_artist_mbids(connection, mbids):
+    """Returns the recording Metadata from recording_json table using artist MBIDs."""
+
+    # convert_json_array_to_sorted_uuid_array is a custom function for implementation
+    # details check admin/sql/create_functions.sql
+    recordings = connection.execute(text("""
+        SELECT recording_json.data
+          FROM recording_json
+         WHERE convert_json_array_to_sorted_uuid_array(data -> 'artist_mbids') = :mbids
+    """), {
+        "mbids": mbids,
+    })
+
+    return [recording[0] for recording in recordings]
+
+
 def create_artist_credit_clusters_without_considering_anomalies(connection):
     """Creates cluster for artist_credit without considering anomalies (A single MSID
        pointing to multiple MBIDs arrays in artist_credit_redirect table).
@@ -340,7 +356,8 @@ def create_artist_credit_clusters_without_considering_anomalies(connection):
         fetch_unclustered_gids_for_artist_credit_mbids,
         get_artist_cluster_id_using_artist_mbids,
         link_artist_mbids_to_artist_credit_cluster_id,
-        insert_artist_credit_cluster
+        insert_artist_credit_cluster,
+        get_recordings_metadata_using_artist_mbids
     )
 
 
@@ -358,7 +375,8 @@ def create_artist_credit_clusters_for_anomalies(connection):
         fetch_artist_credits_left_to_cluster,
         get_artist_gids_from_recording_json_using_mbids,
         get_cluster_id_using_msid,
-        link_artist_mbids_to_artist_credit_cluster_id
+        link_artist_mbids_to_artist_credit_cluster_id,
+        get_recordings_metadata_using_artist_mbids
     )
 
 

--- a/messybrainz/db/release.py
+++ b/messybrainz/db/release.py
@@ -217,6 +217,20 @@ def get_release_mbids_using_msid(connection, release_msid):
     return None
 
 
+def get_recordings_metadata_using_release_mbid(connection, mbid):
+    """Returns the recording Metadata from recording_json table using release MBID."""
+
+    recordings = connection.execute(text("""
+        SELECT recording_json.data
+          FROM recording_json
+         WHERE (data ->> 'release_mbid')::uuid = :mbid
+    """), {
+        "mbid": mbid,
+    })
+
+    return [recording[0] for recording in recordings]
+
+
 def create_release_clusters_without_considering_anomalies(connection):
     """Creates clusters for release MBIDs present in the recording_json table
        without considering anomalies.
@@ -234,7 +248,8 @@ def create_release_clusters_without_considering_anomalies(connection):
         fetch_unclustered_gids_for_release_mbid,
         get_release_cluster_id_using_release_mbid,
         link_release_mbid_to_release_msid,
-        insert_release_cluster
+        insert_release_cluster,
+        get_recordings_metadata_using_release_mbid
     )
 
 
@@ -253,7 +268,8 @@ def create_release_clusters_for_anomalies(connection):
         fetch_release_left_to_cluster,
         get_release_gids_from_recording_json_using_mbid,
         get_cluster_id_using_msid,
-        link_release_mbid_to_release_msid
+        link_release_mbid_to_release_msid,
+        get_recordings_metadata_using_release_mbid
     )
 
 

--- a/messybrainz/db/release.py
+++ b/messybrainz/db/release.py
@@ -51,7 +51,7 @@ def fetch_unclustered_gids_for_release_mbid(connection, release_mbid):
     return [gid[0] for gid in gids]
 
 
-def fetch_distinct_release_mbids(connection):
+def fetch_unclustered_distinct_release_mbids(connection):
     """Fetch all the distinct release MBIDs we have in recording_json table
        but don't have their corresponding MSIDs in release_cluster table.
 
@@ -230,7 +230,7 @@ def create_release_clusters_without_considering_anomalies(connection):
     """
 
     return db_common.create_entity_clusters_without_considering_anomalies(connection,
-        fetch_distinct_release_mbids,
+        fetch_unclustered_distinct_release_mbids,
         fetch_unclustered_gids_for_release_mbid,
         get_release_cluster_id_using_release_mbid,
         link_release_mbid_to_release_msid,

--- a/messybrainz/db/release.py
+++ b/messybrainz/db/release.py
@@ -1,0 +1,284 @@
+from messybrainz import db
+from sqlalchemy import text
+
+def insert_release_cluster(connection, cluster_id, release_gids):
+    """Creates new cluster in the release_cluster table.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        cluster_id (UUID): the release MSID which will represent the cluster.
+        release_gids (list): the list of MSIDs which will form a cluster.
+    """
+
+    values = [
+        {"cluster_id": cluster_id, "release_gid": release_gid} for release_gid in release_gids
+    ]
+
+    connection.execute(text("""
+        INSERT INTO release_cluster (cluster_id, release_gid, updated)
+             VALUES (:cluster_id, :release_gid, now())
+    """), values
+    )
+
+
+def fetch_unclustered_gids_for_release_mbid(connection, release_mbid):
+    """Fetches the gids corresponding to a release_mbid that are
+       not present in release_cluster table.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        release_mbid (UUID): the release MBID for which gids are to be fetched.
+
+    Returns:
+        List of gids.
+    """
+
+    gids = connection.execute(text("""
+        SELECT DISTINCT rec.release
+                   FROM recording_json AS recj
+                   JOIN recording AS rec
+                     ON recj.id = rec.data
+              LEFT JOIN release_cluster AS relc
+                     ON rec.release = relc.release_gid
+                  WHERE recj.data ->> 'release_mbid' = :release_mbid
+                    AND relc.release_gid IS NULL
+    """), {
+        "release_mbid": release_mbid,
+    })
+
+    return [gid[0] for gid in gids]
+
+
+def fetch_distinct_release_mbids(connection):
+    """Fetch all the distinct release MBIDs we have in recording_json table
+       but don't have their corresponding MSIDs in release_cluster table.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+
+    Returns:
+        release_mbids(list): list of release MBIDs.
+    """
+
+    release_mbids = connection.execute(text("""
+        SELECT DISTINCT recj.data ->> 'release_mbid'
+                   FROM recording_json AS recj
+                   JOIN recording AS rec
+                     ON rec.data = recj.id
+              LEFT JOIN release_cluster AS relc
+                     ON rec.release = relc.release_gid
+                  WHERE recj.data ->> 'release_mbid' IS NOT NULL
+                    AND relc.release_gid IS NULL
+    """))
+
+    return [release_mbid[0] for release_mbid in release_mbids]
+
+
+def link_release_mbid_to_release_msid(connection, cluster_id, mbid):
+    """Links the release mbid to the cluster_id.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        cluster_id: the gid which represents the cluster.
+        mbid: mbid for the cluster.
+    """
+
+    connection.execute(text("""
+        INSERT INTO release_redirect (release_cluster_id, release_mbid)
+             VALUES (:cluster_id, :mbid)
+    """), {
+        "cluster_id": cluster_id,
+        "mbid": mbid,
+    })
+
+
+def truncate_release_cluster_and_release_redirect_table():
+    """Truncates release_cluster and release_redirect tables."""
+
+    with db.engine.begin() as connection:
+        connection.execute(text("""TRUNCATE TABLE release_cluster"""))
+        connection.execute(text("""TRUNCATE TABLE release_redirect"""))
+
+
+def get_release_cluster_id_using_release_mbid(connection, release_mbid):
+    """Returns cluster_id for a required release MBID.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        release_mbid (UUID): release MBID for the cluster.
+
+    Returns:
+        cluster_id (UUID): MSID that represents the cluster if it exists else None.
+    """
+
+    cluster_id = connection.execute(text("""
+        SELECT release_cluster_id
+          FROM release_redirect
+         WHERE release_mbid = :release_mbid
+    """), {
+        "release_mbid": release_mbid
+    })
+
+    if cluster_id.rowcount:
+        return cluster_id.fetchone()['release_cluster_id']
+    else:
+        return None
+
+
+
+def fetch_release_left_to_cluster(connection):
+    """ Returns a list of release MBID for the release MBIDs that
+        were not added to redirect table after executing
+        the first phase of clustering. These are anomalies.
+    """
+
+    result = connection.execute(text("""
+        SELECT DISTINCT recj.data ->> 'release_mbid'
+                   FROM recording AS rec
+                   JOIN recording_json AS recj
+                     ON rec.data = recj.id
+              LEFT JOIN release_redirect AS relr
+                     ON (recj.data ->> 'release_mbid')::uuid = relr.release_mbid
+                  WHERE recj.data ->> 'release_mbid' IS NOT NULL
+                    AND relr.release_mbid IS NULL
+    """))
+
+    return [r[0] for r in result]
+
+
+def get_release_gids_from_recording_json_using_mbid(connection, release_mbid):
+    """Returns release MSIDs using a release MBID.
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        release_mbid (UUID): a release MBID for which gids are to be fetched.
+    Returns:
+        gids(list): list of release gids for a given release MBID.
+    """
+
+    result = connection.execute(text("""
+        SELECT DISTINCT r.release
+                   FROM recording AS r
+                   JOIN recording_json AS rj
+                     ON r.data = rj.id
+                  WHERE :release_mbid = (rj.data ->> 'release_mbid')::uuid
+    """), {
+        "release_mbid": release_mbid,
+    })
+
+    return [release_gid[0] for release_gid in result]
+
+
+def get_cluster_id_using_msid(connection, msid):
+    """ Gets the release cluster ID for a given release MSID.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+        msid(UUID): a release gid for which cluster_id is to be fetched.
+
+    Returns:
+        cluster_id(UUID): cluster_id for the queried MSID if found. Else None is returned.
+    """
+
+    result = connection.execute(text("""
+        SELECT cluster_id
+          FROM release_cluster
+         WHERE release_gid = :msid
+    """), {
+        "msid": msid,
+    })
+
+    if result.rowcount:
+        return result.fetchone()[0]
+    return None
+
+
+def get_release_mbids_using_msid(connection, release_msid):
+    """Returns a list of release MBIDs that corresponds
+       to the given release MSID.
+    """
+
+    cluster_id = get_cluster_id_using_msid(connection, release_msid)
+    if cluster_id is None:
+        return None
+
+    mbids = connection.execute(text("""
+        SELECT release_mbid
+          FROM release_redirect
+         WHERE release_cluster_id = :cluster_id
+    """), {
+        "cluster_id": cluster_id,
+    })
+
+    if mbids.rowcount:
+        return [mbid[0] for mbid in mbids]
+
+    return None
+
+
+def create_release_clusters_without_considering_anomalies(connection):
+    """Creates clusters for release MBIDs present in the recording_json table
+       without considering anomalies.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+
+    Returns:
+        clusters_modified (int): number of clusters modified by the script.
+        clusters_add_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    clusters_modified = 0
+    clusters_add_to_redirect = 0
+    release_mbids = fetch_distinct_release_mbids(connection)
+    for release_mbid in release_mbids:
+        gids = fetch_unclustered_gids_for_release_mbid(connection, release_mbid)
+        if gids:
+            cluster_id = get_release_cluster_id_using_release_mbid(connection, release_mbid)
+            if not cluster_id:
+                cluster_id = gids[0]
+                link_release_mbid_to_release_msid(connection, cluster_id, release_mbid)
+                clusters_add_to_redirect +=1
+            insert_release_cluster(connection, cluster_id, gids)
+            clusters_modified += 1
+
+    return clusters_modified, clusters_add_to_redirect
+
+
+def create_release_clusters_for_anomalies(connection):
+    """Creates clusters for release MBIDs present in the recording_json table
+       considering anomalies.
+
+    Args:
+        connection: the sqlalchemy db connection to be used to execute queries
+
+    Returns:
+        clusters_add_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    clusters_add_to_redirect = 0
+    release_left = fetch_release_left_to_cluster(connection)
+    for release_mbid in release_left:
+        release_gids = get_release_gids_from_recording_json_using_mbid(connection, release_mbid)
+        cluster_ids = {get_cluster_id_using_msid(connection, release_gid) for release_gid in release_gids}
+        for cluster_id in cluster_ids:
+            link_release_mbid_to_release_msid(connection, cluster_id, release_mbid)
+            clusters_add_to_redirect += 1
+
+    return clusters_add_to_redirect
+
+
+def create_release_clusters():
+    """Creates clusters for release MBIDs present in the recording_json table.
+
+    Returns:
+        clusters_modified (int): number of clusters modified by the script.
+        clusters_add_to_redirect (int): number of clusters added to redirect table.
+    """
+
+    clusters_modified = 0
+    clusters_add_to_redirect = 0
+    with db.engine.begin() as connection:
+        clusters_modified, clusters_add_to_redirect = create_release_clusters_without_considering_anomalies(connection)
+        clusters_add_to_redirect += create_release_clusters_for_anomalies(connection)
+
+    return clusters_modified, clusters_add_to_redirect

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -598,3 +598,20 @@ class ArtistTestCase(DatabaseTestCase):
             self.assertListEqual(artist_mbids, [
                 [UUID("164f0d73-1234-4e2c-8743-d77bf2191051"), UUID("c2e49f7a-cd6f-48ca-8596-b03614ea4fe8")]
             ])
+
+
+    def test_get_recordings_metadata_using_artist_mbids(self):
+        """ Tests if recordings metadata is fetched correctly using artist MBIDs. """
+
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "artist_mbids": ["859d0860-d480-4efd-970c-c05d5f1776b8", "f82bcf78-5b69-4622-a5ef-73800768d9ac"],
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "title": "'03 Bonnie and Clyde",
+        }
+        submit_listens([recording_1])
+        with db.engine.begin() as connection:
+            recordings = artist.get_recordings_metadata_using_artist_mbids(connection,
+                [UUID("859d0860-d480-4efd-970c-c05d5f1776b8"), UUID("f82bcf78-5b69-4622-a5ef-73800768d9ac")],
+            )
+            self.assertDictEqual(recording_1, recordings[0])

--- a/messybrainz/db/tests/test_release.py
+++ b/messybrainz/db/tests/test_release.py
@@ -3,7 +3,7 @@ from messybrainz import submit_listens_and_sing_me_a_sweet_song as submit_listen
 from messybrainz import db
 from messybrainz.db import data
 from messybrainz.db.testing import DatabaseTestCase
-from messybrainz.db.release import fetch_distinct_release_mbids,\
+from messybrainz.db.release import fetch_unclustered_distinct_release_mbids,\
                                     fetch_unclustered_gids_for_release_mbid,\
                                     link_release_mbid_to_release_msid,\
                                     get_release_cluster_id_using_release_mbid,\
@@ -48,7 +48,7 @@ class ReleaseTestCase(DatabaseTestCase):
         return msb_listens
 
 
-    def test_fetch_distinct_release_mbids(self):
+    def test_fetch_unclustered_distinct_release_mbids(self):
         """Tests if release_mbids are correctly fetched from recording_json table."""
 
         msb_listens = self._load_test_data('recordings_for_release_clusters.json')
@@ -62,7 +62,7 @@ class ReleaseTestCase(DatabaseTestCase):
             '801678aa-5d30-4342-8227-e9618f164cca',
         }
         with db.engine.begin() as connection:
-            release_mbids_fetched = fetch_distinct_release_mbids(connection)
+            release_mbids_fetched = fetch_unclustered_distinct_release_mbids(connection)
             self.assertEqual(len(release_mbids_fetched), 7)
             self.assertSetEqual(release_mbids_submitted, set(release_mbids_fetched))
 

--- a/messybrainz/db/tests/test_release.py
+++ b/messybrainz/db/tests/test_release.py
@@ -14,7 +14,8 @@ from messybrainz.db.release import fetch_unclustered_distinct_release_mbids,\
                                     create_release_clusters,\
                                     get_release_gids_from_recording_json_using_mbid,\
                                     get_release_mbids_using_msid,\
-                                    create_release_clusters_for_anomalies
+                                    create_release_clusters_for_anomalies,\
+                                    get_recordings_metadata_using_release_mbid
 from uuid import UUID
 
 
@@ -405,3 +406,19 @@ class ReleaseTestCase(DatabaseTestCase):
             clusters_modified, clusters_add_to_redirect = create_release_clusters()
             self.assertEqual(clusters_modified, 0)
             self.assertEqual(clusters_add_to_redirect, 0)
+
+
+    def test_get_recordings_metadata_using_release_mbid(self):
+        """ Tests if recordings metadata is fetched correctly using release MBID. """
+
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "title": "'03 Bonnie & Clyde",
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+            "release": "The Blueprint\u00b2: The Gift and The Curse",
+        }
+        submit_listens([recording_1])
+        with db.engine.begin() as connection:
+            recordings = get_recordings_metadata_using_release_mbid(connection, recording_1["release_mbid"])
+            self.assertDictEqual(recording_1, recordings[0])

--- a/messybrainz/db/tests/test_release.py
+++ b/messybrainz/db/tests/test_release.py
@@ -1,0 +1,407 @@
+import json
+from messybrainz import submit_listens_and_sing_me_a_sweet_song as submit_listens
+from messybrainz import db
+from messybrainz.db import data
+from messybrainz.db.testing import DatabaseTestCase
+from messybrainz.db.release import fetch_distinct_release_mbids,\
+                                    fetch_unclustered_gids_for_release_mbid,\
+                                    link_release_mbid_to_release_msid,\
+                                    get_release_cluster_id_using_release_mbid,\
+                                    insert_release_cluster,\
+                                    fetch_release_left_to_cluster,\
+                                    create_release_clusters_without_considering_anomalies,\
+                                    get_cluster_id_using_msid,\
+                                    create_release_clusters,\
+                                    get_release_gids_from_recording_json_using_mbid,\
+                                    get_release_mbids_using_msid,\
+                                    create_release_clusters_for_anomalies
+from uuid import UUID
+
+
+class ReleaseTestCase(DatabaseTestCase):
+    def _load_test_data(self, filename):
+        """Loads data for tests from a given JSON file name."""
+
+        with open(self.path_to_data_file(filename)) as f:
+            recordings = json.load(f)
+        
+        msb_listens = []
+        for recording in recordings:
+            messy_dict = {
+                'artist': recording['artist'],
+                'title': recording['title'],
+            }
+            if 'release' in recording:
+                messy_dict['release'] = recording['release']
+            if 'artist_mbids' in recording:
+                messy_dict['artist_mbids'] = recording['artist_mbids']
+            if 'release_mbid' in recording:
+                messy_dict['release_mbid'] = recording['release_mbid']
+            if 'recording_mbid' in recording:
+                messy_dict['recording_mbid'] = recording['recording_mbid']
+            if 'track_number' in recording:
+                messy_dict['track_number'] = recording['track_number']
+            if 'spotify_id' in recording:
+                messy_dict['spotify_id'] = recording['spotify_id']
+            msb_listens.append(messy_dict)
+
+        return msb_listens
+
+
+    def test_fetch_distinct_release_mbids(self):
+        """Tests if release_mbids are correctly fetched from recording_json table."""
+
+        msb_listens = self._load_test_data('recordings_for_release_clusters.json')
+        submit_listens(msb_listens)
+        release_mbids_submitted = {'7111c8bc-8549-4abc-8ab9-db13f65b4a55',
+            '5f7853be-1f7a-4850-b0b8-2333d6b0318f',
+            '09701309-2f7b-4537-a066-daa1c79b3f06',
+            'd75e103c-5ef4-4146-ae81-e27d19dc7fc4',
+            '2c5e4198-24cf-3c95-a16e-83be8e877dfa',
+            'e8c8bbf8-15c1-477f-af5b-2c1479af037e',
+            '801678aa-5d30-4342-8227-e9618f164cca',
+        }
+        with db.engine.begin() as connection:
+            release_mbids_fetched = fetch_distinct_release_mbids(connection)
+            self.assertEqual(len(release_mbids_fetched), 7)
+            self.assertSetEqual(release_mbids_submitted, set(release_mbids_fetched))
+
+
+    def test_fetch_unclustered_gids_for_release_mbid(self):
+        """Tests if gids are correctly fetched."""
+
+        # recording_1 and recording_2 differ in the name of release
+        # for recording_1 release has 'and' and for recording_2
+        # release has '&'
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "title": "'03 Bonnie & Clyde",
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+            "release": "The Blueprint\u00b2: The Gift and The Curse",
+        }
+
+        recording_2 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "title": "'03 Bonnie & Clyde",
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+            "release":"The Blueprint\u00b2: The Gift & The Curse",
+        }
+        submit_listens([recording_1, recording_2])
+
+        with db.engine.begin() as connection:
+            gids = fetch_unclustered_gids_for_release_mbid(connection, '2c5e4198-24cf-3c95-a16e-83be8e877dfa')
+            gid_fetched = set(gids)
+            gid_from_data = set([UUID(data.get_release(connection, recording_1['release'])),
+                UUID(data.get_release(connection, recording_2['release'])),
+            ])
+
+            self.assertSetEqual(gid_fetched, gid_from_data)
+
+
+    def test_link_release_mbid_to_release_msid(self):
+        """Tests if MBIDs are linked to MSIDs correctly."""
+
+        recording = {
+            "artist": "Jay‐Z & Beyoncé",
+            "title": "'03 Bonnie & Clyde",
+            "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+            "release":"The Blueprint\u00b2: The Gift & The Curse",
+        }
+        submit_listens([recording])
+        mbid = recording['release_mbid']
+        with db.engine.begin() as connection:
+            msid = UUID(data.get_release(connection, recording['release']))
+            result = get_release_cluster_id_using_release_mbid(connection, mbid)
+            self.assertIsNone(result)
+            link_release_mbid_to_release_msid(connection, msid, mbid)
+            result = get_release_cluster_id_using_release_mbid(connection, mbid)
+            self.assertEqual(msid, result)
+
+
+    def test_insert_release_cluster(self):
+        """Tests if clusters are inserted properly into release_cluster table."""
+
+        # recording_1 and recording_2 differ in the name of release
+        # for recording_1 release has 'and' and for recording_2
+        # release has '&'
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "title": "'03 Bonnie & Clyde",
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+            "release": "The Blueprint\u00b2: The Gift and The Curse",
+        }
+
+        recording_2 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "title": "'03 Bonnie & Clyde",
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+            "release":"The Blueprint\u00b2: The Gift & The Curse",
+        }
+        submit_listens([recording_1, recording_2])
+
+        with db.engine.begin() as connection:
+            release_gids = fetch_unclustered_gids_for_release_mbid(connection, '2c5e4198-24cf-3c95-a16e-83be8e877dfa')
+            insert_release_cluster(connection, release_gids[0], release_gids)
+            release_gids = fetch_unclustered_gids_for_release_mbid(connection, '2c5e4198-24cf-3c95-a16e-83be8e877dfa')
+            self.assertEqual(len(release_gids), 0)
+
+
+    def test_fetch_release_left_to_cluster(self):
+        """Tests if release left to cluster after first
+           pass are correctly fetched.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_release_clusters.json")
+        submit_listens(msb_listens)
+
+        with db.engine.begin() as connection:
+            create_release_clusters_without_considering_anomalies(connection)
+            # In the data used from recordings_for_release_clusters
+            # the recordings for release 'The Blueprint\u00b2: The Gift & The Curse'
+            # represents anomaly as two release_mbids exists for this release
+            # (2c5e4198-24cf-3c95-a16e-83be8e877dfa, 801678aa-5d30-4342-8227-e9618f164cca)
+            # and release 'The Notorious KIM' also represents two release_mbids
+            # (e8c8bbf8-15c1-477f-af5b-2c1479af037e, 09701309-2f7b-4537-a066-daa1c79b3f06)
+
+            release_left = fetch_release_left_to_cluster(connection)
+            self.assertEqual(len(release_left), 2)
+
+            # 'The Blueprint\u00b2: The Gift & The Curse' with release MBID '2c5e4198-24cf-3c95-a16e-83be8e877dfa'
+            # was clustered in the first phase, The Notorious KIM' with release MBID
+            # '09701309-2f7b-4537-a066-daa1c79b3f06' was clustered in first phase.
+
+            self.assertSetEqual(set(release_left),
+                set(['801678aa-5d30-4342-8227-e9618f164cca', 'e8c8bbf8-15c1-477f-af5b-2c1479af037e'])
+            )
+
+
+    def test_get_cluster_id_using_msid(self):
+        """Tests if cluster_id is correctly retrived using any MSID for the cluster."""
+
+        msb_listens = self._load_test_data("recordings_for_release_clusters.json")
+        submit_listens(msb_listens)
+
+        create_release_clusters()
+        with db.engine.begin() as connection:
+            gid_from_data = data.get_release(connection, "The Blueprint\u00b2: The Gift & The Curse")
+            cluster_id_1 = get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = data.get_release(connection, "The Blueprint\u00b2: The Gift and The Curse")
+            cluster_id_2 = get_cluster_id_using_msid(connection, gid_from_data)
+
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+
+    def test_get_release_gids_from_recording_json_using_mbids(self):
+        """Tests if release_gids are correctly fetched using a given release MBID"""
+
+        msb_listens = self._load_test_data("recordings_for_release_clusters.json")
+        submit_listens(msb_listens)
+
+        with db.engine.begin() as connection:
+            mbid = UUID("2c5e4198-24cf-3c95-a16e-83be8e877dfa")
+            gids = set(get_release_gids_from_recording_json_using_mbid(connection, mbid))
+            gids_from_data = set([
+                UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift & The Curse")),
+                UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift and The Curse")),
+            ])
+
+            self.assertSetEqual(gids, gids_from_data)
+
+
+    def test_get_release_mbids_using_msid(self):
+        """Test if release_mbid are fetched correctly for a given MSID"""
+
+        msb_listens = self._load_test_data("recordings_for_release_clusters.json")
+        submit_listens(msb_listens)
+        create_release_clusters()
+
+        with db.engine.begin() as connection:
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift & The Curse"))
+            release_mbid_1 = get_release_mbids_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift and The Curse"))
+            release_mbid_2 = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertEqual(release_mbid_1, release_mbid_2)
+
+
+    def test_create_release_clusters_without_considering_anomalies(self):
+        """Tests if clusters are created without considering anomalies are
+           are correctly formed.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_release_clusters.json")
+        submit_listens(msb_listens)
+
+        with db.engine.begin() as connection:
+            clusters_modified, clusters_add_to_redirect = create_release_clusters_without_considering_anomalies(connection)
+            self.assertEqual(clusters_modified, 5)
+            self.assertEqual(clusters_add_to_redirect, 5)
+
+            # 'The Blueprint\u00b2: The Gift & The Curse' and 'The Blueprint\u00b2: The Gift and The Curse'
+            # form one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift & The Curse"))
+            release_mbids_1 = get_release_mbids_using_msid(connection, gid_from_data)
+            cluster_id_1 = get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift and The Curse"))
+            release_mbids_2 = get_release_mbids_using_msid(connection, gid_from_data)
+            cluster_id_2 = get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids_1, release_mbids_2)
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+            # 'The Blueprint Collector's Edition' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint Collector's Edition"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("d75e103c-5ef4-4146-ae81-e27d19dc7fc4")])
+
+            # 'Syreeta' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "Syreeta"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("5f7853be-1f7a-4850-b0b8-2333d6b0318f")])
+
+            # 'Blueprint 2.1' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "Blueprint 2.1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("7111c8bc-8549-4abc-8ab9-db13f65b4a55")])
+
+            # 'The Notorious KIM' with MBID '09701309-2f7b-4537-a066-daa1c79b3f06' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Notorious KIM"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("09701309-2f7b-4537-a066-daa1c79b3f06")])
+
+
+    def test_create_release_clusters_for_anomalies(self):
+        """Tests if clusters are created correctly for the anomalies."""
+
+        msb_listens = self._load_test_data("recordings_for_release_clusters.json")
+        submit_listens(msb_listens)
+
+        with db.engine.begin() as connection:
+            clusters_modified, clusters_add_to_redirect = create_release_clusters_without_considering_anomalies(connection)
+            self.assertEqual(clusters_modified, 5)
+            self.assertEqual(clusters_add_to_redirect, 5)
+
+            # Before clustering anomalies
+            # 'The Notorious KIM' with release MBID '09701309-2f7b-4537-a066-daa1c79b3f06'
+            # is clustered as before no release_gid exists with this release
+            # in release_cluster table before this is inserted.
+            # 'The Blueprint\u00b2: The Gift & The Curse' with release MBID '2c5e4198-24cf-3c95-a16e-83be8e877dfa'
+            # has been clustered.
+            gid_from_data = UUID(data.get_release(connection, "The Notorious KIM"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("09701309-2f7b-4537-a066-daa1c79b3f06")])
+
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift & The Curse"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("2c5e4198-24cf-3c95-a16e-83be8e877dfa")])
+
+            clusters_add_to_redirect = create_release_clusters_for_anomalies(connection)
+            self.assertEqual(clusters_add_to_redirect, 2)
+
+            # After clustering anomalies
+            # 'The Notorious KIM' with release MBID 'e8c8bbf8-15c1-477f-af5b-2c1479af037e'
+            # is clustered and 'The Blueprint\u00b2: The Gift & The Curse' with release MBID
+            # '801678aa-5d30-4342-8227-e9618f164cca' is clustered
+            gid_from_data = UUID(data.get_release(connection, "The Notorious KIM"))
+            release_mbids = set(get_release_mbids_using_msid(connection, gid_from_data))
+            self.assertSetEqual(release_mbids, set([
+                UUID("09701309-2f7b-4537-a066-daa1c79b3f06"),
+                UUID("e8c8bbf8-15c1-477f-af5b-2c1479af037e"),
+            ]))
+
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift & The Curse"))
+            release_mbids = set(get_release_mbids_using_msid(connection, gid_from_data))
+            self.assertSetEqual(release_mbids, set([
+                UUID("2c5e4198-24cf-3c95-a16e-83be8e877dfa"),
+                UUID("801678aa-5d30-4342-8227-e9618f164cca"),
+            ]))
+
+
+    def test_create_release_clusters(self):
+        """Tests if release clusters are correctly formed."""
+
+        msb_listens = self._load_test_data("recordings_for_release_clusters.json")
+        submit_listens(msb_listens)
+        clusters_modified, clusters_add_to_redirect = create_release_clusters()
+        self.assertEqual(clusters_modified, 5)
+        self.assertEqual(clusters_add_to_redirect, 7)
+
+        with db.engine.begin() as connection:
+            # 'The Blueprint\u00b2: The Gift & The Curse' and 'The Blueprint\u00b2: The Gift and The Curse'
+            # form one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift & The Curse"))
+            release_mbids_1 = get_release_mbids_using_msid(connection, gid_from_data)
+            cluster_id_1 = get_cluster_id_using_msid(connection, gid_from_data)
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift and The Curse"))
+            release_mbids_2 = get_release_mbids_using_msid(connection, gid_from_data)
+            cluster_id_2 = get_cluster_id_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids_1, release_mbids_2)
+            self.assertEqual(cluster_id_1, cluster_id_2)
+
+            # 'The Blueprint Collector's Edition' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint Collector's Edition"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("d75e103c-5ef4-4146-ae81-e27d19dc7fc4")])
+
+            # 'Syreeta' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "Syreeta"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("5f7853be-1f7a-4850-b0b8-2333d6b0318f")])
+
+            # 'Blueprint 2.1' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "Blueprint 2.1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("7111c8bc-8549-4abc-8ab9-db13f65b4a55")])
+
+            # After clustering anomalies
+            # 'The Notorious KIM' with MBID '09701309-2f7b-4537-a066-daa1c79b3f06',
+            # 'e8c8bbf8-15c1-477f-af5b-2c1479af037e' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Notorious KIM"))
+            release_mbids = set(get_release_mbids_using_msid(connection, gid_from_data))
+            self.assertSetEqual(release_mbids, set([
+                UUID("09701309-2f7b-4537-a066-daa1c79b3f06"),
+                UUID("e8c8bbf8-15c1-477f-af5b-2c1479af037e"),
+            ]))
+
+            # 'The Blueprint\u00b2: The Gift & The Curse' with MBID '2c5e4198-24cf-3c95-a16e-83be8e877dfa',
+            # '801678aa-5d30-4342-8227-e9618f164cca' form one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint\u00b2: The Gift & The Curse"))
+            release_mbids = set(get_release_mbids_using_msid(connection, gid_from_data))
+            self.assertSetEqual(release_mbids, set([
+                UUID("2c5e4198-24cf-3c95-a16e-83be8e877dfa"),
+                UUID("801678aa-5d30-4342-8227-e9618f164cca"),
+            ]))
+
+            # Inserting new recordings
+            # recording_1 is already clustered
+            recording_1 = {
+                "artist": "Jay‐Z and Beyoncé",
+                "title": "'03 Bonnie and Clyde",
+                "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+                "release": "The Blueprint\u00b2: The Gift and The Curse",
+            }
+            # recording_2, recording_3 are new recordings
+            recording_2 = {
+                "artist": "Donal Leace",
+                "title": "Today Won't Come Again",
+                "release_mbid": "2b82a22b-0492-44be-bfd8-d1cee7d259fb",
+                "release": "Donal Leace",
+            }
+            recording_3 = {
+                "artist": "Memphis Minnie",
+                "title": "Banana Man Blues",
+                "release_mbid": "27b3c191-7e46-4d00-b6bb-cdce39c13568",
+                "release": "Please Warm My Weiner: Old Time Hokum Blues",
+            }
+
+            submit_listens([recording_1, recording_2, recording_3])
+            clusters_modified, clusters_add_to_redirect = create_release_clusters()
+            self.assertEqual(clusters_modified, 2)
+            self.assertEqual(clusters_add_to_redirect, 2)
+
+            # After clustering retry creating clusters
+            clusters_modified, clusters_add_to_redirect = create_release_clusters()
+            self.assertEqual(clusters_modified, 0)
+            self.assertEqual(clusters_add_to_redirect, 0)

--- a/messybrainz/testdata/recordings_for_release_clusters.json
+++ b/messybrainz/testdata/recordings_for_release_clusters.json
@@ -1,0 +1,126 @@
+[
+    {
+        "artist": "Jay\u2010Z & Beyonc\u00e9",
+        "title": "'03 Bonnie and Clyde"
+    },
+    {
+        "artist": "Big Sean feat. The\u2010Dream",
+        "title": "Live This Life"
+    },
+    {
+        "artist": "Jay\u2010Z & Beyonc\u00e9",
+        "artist_mbids": [
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+            "859d0860-d480-4efd-970c-c05d5f1776b8"
+        ],
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "release": "The Blueprint\u00b2: The Gift & The Curse",
+        "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+        "title": "'03 Bonnie and Clyde"
+    },
+    {
+        "artist": "Jay\u2010Z & Beyonc\u00e9",
+        "artist_mbids": [
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+            "859d0860-d480-4efd-970c-c05d5f1776b8"
+        ],
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "release": "The Blueprint\u00b2: The Gift and The Curse",
+        "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+        "title": "'03 Bonnie and Clyde"
+    },
+    {
+        "artist": "Jay\u2010Z & Beyonc\u00e9",
+        "artist_mbids": [
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+            "859d0860-d480-4efd-970c-c05d5f1776b8"
+        ],
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "release": "The Blueprint\u00b2: The Gift and The Curse",
+        "release_mbid": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
+        "title": "'03 Bonnie & Clyde"
+    },
+    {
+        "artist": "Jay\u2010Z & Beyonc\u00e9",
+        "artist_mbids": [
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+            "859d0860-d480-4efd-970c-c05d5f1776b8"
+        ],
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "release": "The Blueprint\u00b2: The Gift & The Curse",
+        "release_mbid": "801678aa-5d30-4342-8227-e9618f164cca",
+        "title": "'03 Bonnie & Clyde"
+    },
+    {
+        "artist": "Jay\u2010Z & Beyonc\u00e9",
+        "artist_mbids": [
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+            "859d0860-d480-4efd-970c-c05d5f1776b8"
+        ],
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "release": "The Blueprint\u00b2: The Gift and The Curse",
+        "release_mbid": "801678aa-5d30-4342-8227-e9618f164cca",
+        "title": "'03 Bonnie & Clyde"
+    },
+    {
+        "artist": "Jay\u2010Z & Beyonc\u00e9",
+        "artist_mbids": [
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+            "859d0860-d480-4efd-970c-c05d5f1776b8"
+        ],
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "release": "Blueprint 2.1",
+        "release_mbid": "7111c8bc-8549-4abc-8ab9-db13f65b4a55",
+        "title": "'03 Bonnie & Clyde"
+    },
+    {
+        "artist": "Lil Kim",
+        "artist_mbids": [
+            "bc1b5c95-e6d6-46b5-957a-5e8908b02c1e"
+        ],
+        "recording_mbid": "6ba092ae-aaf7-4154-b987-9eb9d05f8616",
+        "release": "The Notorious KIM",
+        "release_mbid": "e8c8bbf8-15c1-477f-af5b-2c1479af037e",
+        "title": "Don't Mess With Me"
+    },
+    {
+        "artist": "Lil Kim",
+        "artist_mbids": [
+            "bc1b5c95-e6d6-46b5-957a-5e8908b02c1e"
+        ],
+        "recording_mbid": "6ba092ae-aaf7-4154-b987-9eb9d05f8616",
+        "release": "The Notorious KIM",
+        "release_mbid": "09701309-2f7b-4537-a066-daa1c79b3f06",
+        "title": "Don't Mess With Me"
+    },
+    {
+        "artist": "JAY-Z",
+        "artist_mbids": [
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac"
+        ],
+        "recording_mbid": "cad174ad-d683-4858-a205-7bdc4175fff7",
+        "release": "The Blueprint Collector's Edition",
+        "release_mbid": "d75e103c-5ef4-4146-ae81-e27d19dc7fc4",
+        "title": "Some People Hate"
+    },
+    {
+        "artist": "JAY-Z",
+        "artist_mbids": [
+            "f82bcf78-5b69-4622-a5ef-73800768d9ac"
+        ],
+        "recording_mbid": "cad174ad-d683-4858-a205-7bdc4175fff7",
+        "release": "The Blueprint\u00b2: The Gift & The Curse",
+        "release_mbid": "801678aa-5d30-4342-8227-e9618f164cca",
+        "title": "Some People Hate"
+    },
+    {
+        "artist": "Syreeta",
+        "artist_mbids": [
+            "5cfeec75-f6e2-439c-946d-5317334cdc6c"
+        ],
+        "recording_mbid": "9ed38583-437f-4186-8183-9c31ffa2c116",
+        "release": "Syreeta",
+        "release_mbid": "5f7853be-1f7a-4850-b0b8-2333d6b0318f",
+        "title": "She's Leaving Home"
+    }
+]


### PR DESCRIPTION
# Summary
* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
We need to cluster similar releases together and assign MBID to those MSIDs.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-373](https://tickets.metabrainz.org/browse/LB-373)

# Solution
Add functionality which will create clusters for release that have release MBIDs in recording_json table.
This is somewhat similar to what I've written in my proposal
Additional things apart from the proposal:
The clusters are created in 2 phases in phase-1 simple cases are handled and in phase-2 anomalies are handled. This is similar to artist_credit clusters.

# Link to test run:
https://gist.github.com/kartikeyaSh/1c2a2c23787d5bd41c56cc9b56b765db

# Anomalies:
[The Blueprint²: The Gift & The Curse](https://musicbrainz.org/release/2c5e4198-24cf-3c95-a16e-83be8e877dfa) and [The Blueprint²: The Gift & The Curse](https://musicbrainz.org/release/801678aa-5d30-4342-8227-e9618f164cca) have the same release title but different release MBID.