### PR TITLE
LB-374: MessyBrainz: Add functionality to fetch releases using recording MBID

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -57,6 +57,13 @@ CREATE TABLE recording_redirect (
 );
 ALTER TABLE recording_redirect ADD CONSTRAINT recording_redirect_uniq UNIQUE (recording_cluster_id, recording_mbid);
 
+CREATE TABLE recording_release_join (
+  recording_mbid UUID NOT NULL,
+  release_mbid   UUID NOT NULL,
+  release_name   TEXT NOT NULL,
+  updated TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
 CREATE TABLE release (
   gid   UUID NOT NULL,
   title TEXT NOT NULL,

--- a/admin/sql/drop_tables.sql
+++ b/admin/sql/drop_tables.sql
@@ -8,6 +8,7 @@ DROP TABLE IF EXISTS recording_artist_join        CASCADE;
 DROP TABLE IF EXISTS recording_cluster            CASCADE;
 DROP TABLE IF EXISTS recording_json               CASCADE;
 DROP TABLE IF EXISTS recording_redirect           CASCADE;
+DROP TABLE IF EXISTS recording_release_join       CASCADE;
 DROP TABLE IF EXISTS release                      CASCADE;
 DROP TABLE IF EXISTS release_cluster              CASCADE;
 DROP TABLE IF EXISTS release_redirect             CASCADE;

--- a/admin/sql/updates/2018-06-25-create-recording-release-join-table.sql
+++ b/admin/sql/updates/2018-06-25-create-recording-release-join-table.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+CREATE TABLE recording_release_join (
+  recording_mbid UUID NOT NULL,
+  release_mbid   UUID NOT NULL,
+  release_name   TEXT NOT NULL,
+  updated TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+COMMIT;

--- a/manage.py
+++ b/manage.py
@@ -258,7 +258,9 @@ def truncate_release_cluster_and_redirect():
         raise
 
 
-def fetch_and_store_releases():
+@cli.command()
+@click.option("--verbose", "-v", is_flag=True, help="Print debug information.")
+def fetch_and_store_releases(verbose=False):
     """ Fetches releases from the musicbrainz database for the recording MBIDs
         in the recording_json table submitted while submitting a listen. It fetches
         only the releases for the recordings MBIDs which are not in recording_release_join
@@ -266,12 +268,18 @@ def fetch_and_store_releases():
         and the total recording MBIDs it added to the recording_release_join table.
     """
 
+    print("Fetching release for recording MBIDs...")
+    if verbose:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+
     # Init databases
     db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     musicbrainz_db.init_db_engine(config.MB_DATABASE_URI)
 
     try:
+        logging.debug("=" * 80)
         num_recording_mbids_processed, num_recording_mbids_added = release.fetch_and_store_releases_for_all_recording_mbids()
+        logging.debug("=" * 80)
         print("Total recording MBIDs processed: {0}.".format(num_recording_mbids_processed))
         print("Total recording MBIDs added to table: {0}.".format(num_recording_mbids_added))
         print("Done!")

--- a/manage.py
+++ b/manage.py
@@ -199,6 +199,7 @@ def create_artist_credit_clusters_for_mbids(verbose=0):
         print("Done!")
     except Exception as error:
         print("While creating artist_credit clusters. An error occured: {0}".format(error))
+        raise
 
 
 @cli.command()
@@ -242,6 +243,7 @@ def truncate_artist_credit_cluster_and_redirect():
         logging.error("An error occured while truncating artist_credit_cluster"
             "and artist_credit_redirect table: {0}".format(error)
         )
+        raise
 
 
 @cli.command()
@@ -253,6 +255,40 @@ def truncate_release_cluster_and_redirect():
         print("release_cluster and release_redirect table truncated.")
     except Exception as error:
         print("An error occured while truncating release_cluster and release_redirect: {0}".format(error))
+        raise
+
+
+def fetch_and_store_releases():
+    """ Fetches releases from the musicbrainz database for the recording MBIDs
+        in the recording_json table submitted while submitting a listen. It fetches
+        only the releases for the recordings MBIDs which are not in recording_release_join
+        table. In the end it prints to the console the total recording MBIDs it processed
+        and the total recording MBIDs it added to the recording_release_join table.
+    """
+
+    # Init databases
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    musicbrainz_db.init_db_engine(config.MB_DATABASE_URI)
+
+    try:
+        num_recording_mbids_processed, num_recording_mbids_added = release.fetch_and_store_releases_for_all_recording_mbids()
+        print("Total recording MBIDs processed: {0}.".format(num_recording_mbids_processed))
+        print("Total recording MBIDs added to table: {0}.".format(num_recording_mbids_added))
+        print("Done!")
+    except Exception as error:
+        print("Unable to fetch releases. An error occured: {0}".format(error))
+        raise
+
+
+@cli.command()
+def truncate_recording_release_join_table():
+    """Truncate table recording_release_join."""
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    try:
+        release.truncate_recording_release_join()
+        print("Table recording_release_join truncated.")
+    except Exception as error:
+        print("An error occured while truncating recording_release_join table: {0}".format(error))
         raise
 
 

--- a/messybrainz/db/tests/test_release.py
+++ b/messybrainz/db/tests/test_release.py
@@ -549,7 +549,7 @@ class ReleaseTestCase(DatabaseTestCase):
 
         with db.engine.begin() as connection:
             releases_from_join = release.get_releases_for_recording_mbid(connection, recording_mbid)
-            self.assertIsNone(releases_from_join)
+            self.assertListEqual(releases_from_join, [])
 
             releases_fetched = release.fetch_releases_from_musicbrainz_db(connection, recording_mbid)
             release.insert_releases_to_recording_release_join(connection, recording_mbid, releases_fetched)
@@ -635,7 +635,7 @@ class ReleaseTestCase(DatabaseTestCase):
             self.assertSetEqual(set(releases), set(releases_fetched[2]))
 
             releases = release.get_releases_for_recording_mbid(connection, "9ed38583-437f-4186-8183-9c31ffa2c116")
-            self.assertIsNone(releases)
+            self.assertListEqual(releases, [])
 
             submit_listens([recording_1])
             release.fetch_and_store_releases_for_all_recording_mbids()

--- a/messybrainz/testdata/recordings_for_fetch_releases.json
+++ b/messybrainz/testdata/recordings_for_fetch_releases.json
@@ -1,0 +1,18 @@
+[
+    {
+        "title": "Empire State of Mind",
+        "artist": "Jay‐Z + Alicia Keys",
+        "recording_mbid": "4a9818ba-5963-4761-864f-7d96841053d2"
+    },
+    {
+        "title": "Wouldn't You Like to... (radio edit) (feat. Kanye West & Common)",
+        "artist": "Malik Yusef",
+        "recording_mbid": "2977432b-f1a2-4c37-b60f-bac1ce4e0961"
+    },
+    {
+        "title": "'03 Bonnie and Clyde",
+        "artist": "Jay‐Z & Beyoncé",
+        "release": "The Blueprint²: The Gift & The Curse",
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451"
+    }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/metabrainz/brainzutils-python.git@v1.5.0
+git+https://github.com/metabrainz/brainzutils-python.git@v1.5.1
 Fabric == 1.10.2
 Flask-Testing == 0.4.2
 Flask-SQLAlchemy==2.0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MessyBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary
Added functionality to fetch releases using recording MBID.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
We have a lot of recording MBIDs in recording_json table. For those recordings we can fetch release MBIDs which can be used to create release clusters.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_):  [LB-374](https://tickets.metabrainz.org/browse/LB-374) 


# Solution
Add functionality to fetch releases using recording MBIDs present in the recording_json table.
Fetch all the releases for a given recording MBID. releases consist of release MBID and release name.
<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


