### PR TITLE
LB-381: MessyBrainz: create clusters using fetched artist MBIDs.

### DIFF
--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -19,5 +19,6 @@ CREATE INDEX name_ndx_artist_credit ON artist_credit (name);
 CREATE INDEX title_ndx_release ON release (title);
 
 CREATE INDEX recording_mbid_ndx_recording_artist_join ON recording_artist_join (recording_mbid);
+CREATE INDEX artsit_mbids_ndx_recording_artist_join ON recording_artist_join (artist_mbids);
 
 COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -18,6 +18,6 @@ CREATE INDEX cluster_id_ndx_release_cluster ON release_cluster (cluster_id);
 CREATE INDEX name_ndx_artist_credit ON artist_credit (name);
 CREATE INDEX title_ndx_release ON release (title);
 
-CREATE INDEX mbid_ndx_recording ON recording_artist_join (recording_mbid);
+CREATE INDEX recording_mbid_ndx_recording_artist_join ON recording_artist_join (recording_mbid);
 
 COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -32,9 +32,9 @@ CREATE TABLE recording (
 );
 
 CREATE TABLE recording_artist_join (
-  recording_mbid UUID NOT NULL,
-  artist_mbid UUID NOT NULL,
-  updated TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+  recording_mbid        UUID NOT NULL,
+  artist_mbids_array    UUID[] NOT NULL,
+  updated               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 
 CREATE TABLE recording_cluster (

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -18,9 +18,9 @@ ALTER TABLE artist_credit_cluster ADD CONSTRAINT artist_credit_cluster_uniq UNIQ
 
 CREATE TABLE artist_credit_redirect (
   artist_credit_cluster_id UUID NOT NULL, -- FK to artist_credit_cluster.cluster_id
-  artist_mbids_array       UUID[] NOT NULL
+  artist_mbids             UUID[] NOT NULL
 );
-ALTER TABLE artist_credit_redirect ADD CONSTRAINT artist_credit_redirect_artist_mbids_array_uniq UNIQUE (artist_mbids_array);
+ALTER TABLE artist_credit_redirect ADD CONSTRAINT artist_credit_redirect_artist_mbids_uniq UNIQUE (artist_mbids);
 
 CREATE TABLE recording (
   id         SERIAL,
@@ -33,7 +33,7 @@ CREATE TABLE recording (
 
 CREATE TABLE recording_artist_join (
   recording_mbid        UUID NOT NULL,
-  artist_mbids_array    UUID[] NOT NULL,
+  artist_mbids          UUID[] NOT NULL,
   updated               TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 

--- a/admin/sql/updates/2018-06-26-alter-table-artist-credit-redirect.sql
+++ b/admin/sql/updates/2018-06-26-alter-table-artist-credit-redirect.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
 ALTER TABLE artist_credit_redirect DROP COLUMN artist_mbid;
-ALTER TABLE artist_credit_redirect ADD COLUMN artist_mbids_array UUID[] NOT NULL;
+ALTER TABLE artist_credit_redirect ADD COLUMN artist_mbids UUID[] NOT NULL;
 
 COMMIT;

--- a/admin/sql/updates/2018-07-05-alter-recording-artist-join.sql
+++ b/admin/sql/updates/2018-07-05-alter-recording-artist-join.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
 ALTER TABLE recording_artist_join DROP COLUMN artist_mbid;
-ALTER TABLE recording_artist_join ADD COLUMN artist_mbids_array UUID[] NOT NULL;
+ALTER TABLE recording_artist_join ADD COLUMN artist_mbids UUID[] NOT NULL;
 
 COMMIT;

--- a/admin/sql/updates/2018-07-05-alter-recording-artist-join.sql
+++ b/admin/sql/updates/2018-07-05-alter-recording-artist-join.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE recording_artist_join DROP COLUMN artist_mbid;
+ALTER TABLE recording_artist_join ADD COLUMN artist_mbids_array UUID[] NOT NULL;
+
+COMMIT;

--- a/manage.py
+++ b/manage.py
@@ -188,6 +188,8 @@ def create_artist_credit_clusters_for_mbids(verbose='WARNING'):
             logging.basicConfig(format='%(message)s', level=logging.INFO)
         elif verbose == 'DEBUG':
             logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+        else:
+            print("Invalid logging level specified. Using default logging level(WARNING).")
 
         print("Creating artist_credit clusters...")
 
@@ -302,21 +304,23 @@ def truncate_recording_release_join_table():
 
 
 @cli.command()
-@click.option("--verbose", "-v", default=0, help="Print debug information for given verbose level(0,1,2).")
-def create_clusters_using_fetched_artist_mbids(verbose=0):
+@click.option("--verbose", "-v", default="WARNING", help="Print debug information for given verbose level(WARNING, INFO, DEBUG).")
+def create_clusters_using_fetched_artist_mbids(verbose="WARNING"):
     """Creates clusters for artist_credits using artist MBIDs fetched from MusicBrainz
        database and stored in recording_artist_join table.
     """
 
-    if verbose == 1:
-        logging.basicConfig(format='%(message)s', level=logging.INFO)
-    elif verbose == 2:
-        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
-
-    print("Creating artist_credit clusters...")
-
-    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
+        if verbose == "INFO":
+            logging.basicConfig(format='%(message)s', level=logging.INFO)
+        elif verbose == "DEBUG":
+            logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+        elif verbose != "WARNING":
+            print("Invalid logging level specified. Using default logging level(WARNING).")
+
+        print("Creating artist_credit clusters...")
+        db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+
         logging.debug("=" * 80)
         clusters_modified, clusters_add_to_redirect = artist.create_clusters_using_fetched_artist_mbids()
         logging.debug("=" * 80)

--- a/manage.py
+++ b/manage.py
@@ -177,21 +177,21 @@ def truncate_recording_artist_join_table():
 
 
 @cli.command()
-@click.option("--verbose", "-v", default=0, help="Print debug information for given verbose level(0,1,2).")
-def create_artist_credit_clusters_for_mbids(verbose=0):
+@click.option("--verbose", "-v", default='WARNING', help="Print debug information for given verbose level(WARNING, INFO, DEBUG).")
+def create_artist_credit_clusters_for_mbids(verbose='WARNING'):
     """Creates clusters for artist_credits using artist MBIDs present in
        recording_json table.
     """
 
-    if verbose == 1:
-        logging.basicConfig(format='%(message)s', level=logging.INFO)
-    elif verbose == 2:
-        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
-
-    print("Creating artist_credit clusters...")
-
-    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
+        if verbose == 'INFO':
+            logging.basicConfig(format='%(message)s', level=logging.INFO)
+        elif verbose == 'DEBUG':
+            logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+
+        print("Creating artist_credit clusters...")
+
+        db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
         logging.debug("=" * 80)
         clusters_modified, clusters_add_to_redirect = create_artist_credit_clusters()
         logging.debug("=" * 80)

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,7 @@ from messybrainz.db.artist import truncate_recording_artist_join,\
                                 fetch_and_store_artist_mbids_for_all_recording_mbids,\
                                 create_artist_credit_clusters,\
                                 truncate_artist_credit_cluster_and_redirect_tables
+from messybrainz.db import artist
 from messybrainz.db import release
 from messybrainz.webserver import create_app
 from brainzutils import musicbrainz_db
@@ -298,6 +299,32 @@ def truncate_recording_release_join_table():
     except Exception as error:
         print("An error occured while truncating recording_release_join table: {0}".format(error))
         raise
+
+
+@cli.command()
+@click.option("--verbose", "-v", default=0, help="Print debug information for given verbose level(0,1,2).")
+def create_clusters_using_fetched_artist_mbids(verbose=0):
+    """Creates clusters for artist_credits using artist MBIDs fetched from MusicBrainz
+       database and stored in recording_artist_join table.
+    """
+
+    if verbose == 1:
+        logging.basicConfig(format='%(message)s', level=logging.INFO)
+    elif verbose == 2:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+
+    print("Creating artist_credit clusters...")
+
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    try:
+        logging.debug("=" * 80)
+        clusters_modified, clusters_add_to_redirect = artist.create_clusters_using_fetched_artist_mbids()
+        logging.debug("=" * 80)
+        print("Clusters modified: {0}.".format(clusters_modified))
+        print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
+        print("Done!")
+    except Exception as error:
+        print("While creating artist_credit clusters using fetched artist MBIDs. An error occured: {0}".format(error))
 
 
 if __name__ == '__main__':

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -42,7 +42,7 @@ def fetch_recording_mbids_not_in_recording_artist_join(connection):
         SELECT DISTINCT rj.data ->> 'recording_mbid'
                    FROM recording_json AS rj
               LEFT JOIN recording_artist_join AS raj
-                     ON (rj.data ->> 'recording_mbid')::uuid = raj.recording_mbid
+                     ON rj.data ->> 'recording_mbid' = (raj.recording_mbid)::text
                   WHERE rj.data ->> 'recording_mbid' IS NOT NULL
                     AND rj.data ->> 'recording_mbid' != ''
                     AND raj.recording_mbid IS NULL
@@ -410,7 +410,7 @@ def fetch_unclustered_artist_mbids_using_recording_artist_join(connection):
         SELECT DISTINCT raj.artist_mbids
                    FROM recording_json AS rj
                    JOIN recording_artist_join AS raj
-                     ON (rj.data ->> 'recording_mbid')::uuid = raj.recording_mbid
+                     ON (rj.data ->> 'recording_mbid') = (raj.recording_mbid)::text
                    JOIN recording AS r
                      ON r.data = rj.id
               LEFT JOIN artist_credit_cluster AS acc
@@ -438,7 +438,7 @@ def fetch_unclustered_gids_for_artist_mbids_using_recording_artist_join(connecti
         SELECT DISTINCT r.artist
                    FROM recording_json AS rj
                    JOIN recording_artist_join AS raj
-                     ON (rj.data ->> 'recording_mbid')::uuid = raj.recording_mbid
+                     ON (rj.data ->> 'recording_mbid') = (raj.recording_mbid)::text
                    JOIN recording AS r
                      ON rj.id = r.data
               LEFT JOIN artist_credit_cluster AS acc
@@ -465,7 +465,7 @@ def fetch_artist_mbids_left_to_cluster_from_recording_artist_join(connection):
                    JOIN recording_json AS rj
                      ON r.data = rj.id
                    JOIN recording_artist_join AS raj
-                     ON (rj.data ->> 'recording_mbid')::uuid = raj.recording_mbid
+                     ON (rj.data ->> 'recording_mbid') = (raj.recording_mbid)::text
               LEFT JOIN artist_credit_redirect AS acr
                      ON raj.artist_mbids = acr.artist_mbids
                   WHERE acr.artist_mbids IS NULL
@@ -486,7 +486,7 @@ def get_gids_from_recording_using_fetched_artist_mbids(connection, artist_mbids)
                    JOIN recording_json AS rj
                      ON r.data = rj.id
                    JOIN recording_artist_join AS raj
-                     ON (rj.data ->> 'recording_mbid')::uuid = raj.recording_mbid
+                     ON rj.data ->> 'recording_mbid' = (raj.recording_mbid)::text
                   WHERE :artist_mbids = raj.artist_mbids
     """), {
         "artist_mbids": artist_mbids,
@@ -504,7 +504,7 @@ def get_recordings_metadata_using_artist_mbids_and_recording_artist_join(connect
         SELECT rj.data
           FROM recording_json AS rj
           JOIN recording_artist_join AS raj
-            ON (rj.data ->> 'recording_mbid')::uuid = raj.recording_mbid
+            ON rj.data ->> 'recording_mbid' = (raj.recording_mbid)::text
          WHERE raj.artist_mbids = :mbids
     """), {
         "mbids": mbids,

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -473,7 +473,7 @@ def fetch_artist_mbids_left_to_cluster_from_recording_artist_join(connection):
     return [r[0] for r in result]
 
 
-def get_artist_gids_from_recording_using_mbids_and_recording_artist_join(connection, artist_mbids):
+def get_gids_from_recording_using_fetched_artist_mbids(connection, artist_mbids):
     """ Returns artist gids from recording table using artist MBIDs and
         recording_artist_join table using a given list of artist MBIDs.
     """
@@ -530,7 +530,7 @@ def create_clusters_using_fetched_artist_mbids_for_anomalies(connection):
 
     return db_common.create_entity_clusters_for_anomalies(connection,
         fetch_artist_mbids_left_to_cluster_from_recording_artist_join,
-        get_artist_gids_from_recording_using_mbids_and_recording_artist_join,
+        get_gids_from_recording_using_fetched_artist_mbids,
         get_cluster_id_using_msid,
         link_artist_mbids_to_artist_credit_cluster_id,
         get_recordings_metadata_using_artist_mbids

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -494,6 +494,24 @@ def get_gids_from_recording_using_fetched_artist_mbids(connection, artist_mbids)
     return [artist_gid[0] for artist_gid in result]
 
 
+def get_recordings_metadata_using_artist_mbids_and_recording_artist_join(connection, mbids):
+    """ Returns the recording Metadata from recording_json table using artist MBIDs and
+        recording_artist_join.
+    """
+
+    recordings = connection.execute(text("""
+        SELECT rj.data
+          FROM recording_json AS rj
+          JOIN recording_artist_join AS raj
+            ON (rj.data ->> 'recording_mbid')::uuid = raj.recording_mbid
+         WHERE raj.artist_mbids_array = :mbids
+    """), {
+        "mbids": mbids,
+    })
+
+    return [recording[0] for recording in recordings]
+
+
 def create_clusters_using_fetched_artist_mbids_without_anomalies(connection):
     """Creates cluster for artist_credit without considering anomalies (A single MSID
        pointing to multiple MBIDs arrays in artist_credit_redirect table). Using fetched
@@ -512,7 +530,7 @@ def create_clusters_using_fetched_artist_mbids_without_anomalies(connection):
         get_artist_cluster_id_using_artist_mbids,
         link_artist_mbids_to_artist_credit_cluster_id,
         insert_artist_credit_cluster,
-        get_recordings_metadata_using_artist_mbids,
+        get_recordings_metadata_using_artist_mbids_and_recording_artist_join,
     )
 
 
@@ -533,7 +551,7 @@ def create_clusters_using_fetched_artist_mbids_for_anomalies(connection):
         get_gids_from_recording_using_fetched_artist_mbids,
         get_cluster_id_using_msid,
         link_artist_mbids_to_artist_credit_cluster_id,
-        get_recordings_metadata_using_artist_mbids
+        get_recordings_metadata_using_artist_mbids_and_recording_artist_join
     )
 
 

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -44,6 +44,7 @@ def fetch_recording_mbids_not_in_recording_artist_join(connection):
               LEFT JOIN recording_artist_join AS raj
                      ON (rj.data ->> 'recording_mbid')::uuid = raj.recording_mbid
                   WHERE rj.data ->> 'recording_mbid' IS NOT NULL
+                    AND rj.data ->> 'recording_mbid' != ''
                     AND raj.recording_mbid IS NULL
     """))
 

--- a/messybrainz/db/common.py
+++ b/messybrainz/db/common.py
@@ -66,6 +66,13 @@ def create_entity_clusters_for_anomalies(connection,
             clusters_add_to_redirect += 1
             logger.info("=" * 80)
             logger.info("Cluster ID: {0}\n".format(cluster_id))
+            if logger_level == logging.DEBUG:
+                if isinstance(entity_mbid, list):
+                    mbids_str_list = [str(mbid) for mbid in entity_mbid]
+                    mbids_str = ', '.join(mbids_str_list)
+                else:
+                    mbids_str = str(entity_mbid)
+                logger.debug("Cluster MBID: {0}\n".format(mbids_str))
             logger.info("Recordings:")
             if logger_level >= logging.DEBUG:
                 recordings = get_recordings_metadata_using_entity_mbid(connection, entity_mbid)
@@ -128,6 +135,13 @@ def create_entity_clusters_without_considering_anomalies(connection,
             clusters_modified += 1
             logger.info("=" * 80)
             logger.info("Cluster ID: {0}\n".format(cluster_id))
+            if logger_level == logging.DEBUG:
+                if isinstance(entity_mbids, list):
+                    mbids_str_list = [str(mbid) for mbid in entity_mbids]
+                    mbids_str = ', '.join(mbids_str_list)
+                else:
+                    mbids_str = str(entity_mbids)
+                logger.debug("Cluster MBID: {0}\n".format(mbids_str))
             logger.info("Number of entity added to this cluster: {0}.\n".format(len(gids)))
             logger.info("Recordings:")
             if logger_level >= logging.DEBUG:

--- a/messybrainz/db/common.py
+++ b/messybrainz/db/common.py
@@ -47,6 +47,7 @@ def create_entity_clusters_for_anomalies(connection,
                                                                 an entity MBID.
         get_cluster_id_using_msid(function): Gets the cluster ID for a given MSID.
         link_entity_mbid_to_entity_cluster_id(function): Links the entity mbid to the cluster_id.
+        get_recordings_metadata_using_entity_mbid(function): gets recordings metadata using given MBID.
 
     Returns:
         clusters_add_to_redirect (int): number of clusters added to redirect table.
@@ -110,6 +111,7 @@ def create_entity_clusters_without_considering_anomalies(connection,
         link_entity_mbids_to_entity_cluster_id (function): Links the entity mbid to the cluster_id.
         insert_entity_cluster (function): Creates a cluster with given cluster_id in the
                                         entity_cluster table.
+        get_recordings_metadata_using_entity_mbid(function): gets recordings metadata using given MBID.
 
     Returns:
         clusters_modified (int): number of clusters modified.

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -766,6 +766,26 @@ class ArtistTestCase(DatabaseTestCase):
             self.assertSetEqual(gids, gids_from_data)
 
 
+    def test_get_recordings_metadata_using_artist_mbids_and_recording_artist_join(self):
+        """ Tests if recordings metadata is correctly fetched using artist MBIDs and
+            recording_artist_join table.
+        """
+
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "title": "'03 Bonnie and Clyde",
+        }
+        submit_listens([recording_1])
+        self._add_mbids_to_recording_artist_join()
+
+        with db.engine.begin() as connection:
+            recordings = artist.get_recordings_metadata_using_artist_mbids_and_recording_artist_join(connection,
+                [UUID("859d0860-d480-4efd-970c-c05d5f1776b8"), UUID("f82bcf78-5b69-4622-a5ef-73800768d9ac")],
+            )
+            self.assertDictEqual(recording_1, recordings[0])
+
+
     def test_create_clusters_using_fetched_artist_mbids_without_anomalies(self):
         """ Tests if artist clusters are created correctly without considering anomalies."""
 

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -743,7 +743,7 @@ class ArtistTestCase(DatabaseTestCase):
             self.assertListEqual(artist_left, [[UUID("b49a9595-3576-44bb-8ac0-e26d3f5b42ff")]])
 
 
-    def test_get_artist_gids_from_recording_using_mbids_and_recording_artist_join(self):
+    def test_get_gids_from_recording_using_fetched_artist_mbids(self):
         """ Tests if artist gids are correctly fetched from recording table using
             artist MBIDs.
         """
@@ -757,7 +757,7 @@ class ArtistTestCase(DatabaseTestCase):
                         UUID("859d0860-d480-4efd-970c-c05d5f1776b8"),
                         UUID("f82bcf78-5b69-4622-a5ef-73800768d9ac"),
                     ]
-            gids = set(artist.get_artist_gids_from_recording_using_mbids_and_recording_artist_join(connection, mbids))
+            gids = set(artist.get_gids_from_recording_using_fetched_artist_mbids(connection, mbids))
             gids_from_data = set([
                 UUID(data.get_artist_credit(connection, "Jay‐Z & Beyoncé")),
                 UUID(data.get_artist_credit(connection, "Jay‐Z and Beyoncé"))

--- a/messybrainz/testdata/recordings_for_clustering_using_fetched_artist_mbids.json
+++ b/messybrainz/testdata/recordings_for_clustering_using_fetched_artist_mbids.json
@@ -1,0 +1,47 @@
+[
+    {
+        "artist": "Lil’ Kim",
+        "recording_mbid": "6ba092ae-aaf7-4154-b987-9eb9d05f8616",
+        "title": "Don't Mess With Me"
+    },
+    {
+        "artist": "Jay\u2010Z & Beyonc\u00e9",
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "title": "'03 Bonnie and Clyde"
+    },
+    {
+        "artist": "Jay‐Z",
+        "recording_mbid": "9475f8ef-e785-4b9f-a8c2-03ceb817553e",
+        "title": "Takeover"
+    },
+    {
+        "artist": "Jay_Z",
+        "recording_mbid": "9475f8ef-e785-4b9f-a8c2-03ceb817553e",
+        "title": "Takeover"
+    },
+    {
+        "artist": "JAY-Z",
+        "title": "Some People Hate",
+        "recording_mbid": "cad174ad-d683-4858-a205-7bdc4175fff7"
+    },
+    {
+        "artist": "JAY_Z",
+        "title": "Some People Hate",
+        "recording_mbid": "cad174ad-d683-4858-a205-7bdc4175fff7"
+    },
+    {
+        "artist": "Jay\u2010Z and Beyonc\u00e9",
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+        "title": "'03 Bonnie and Clyde"
+    },
+    {
+        "artist": "Syreeta",
+        "artist_mbids": [
+            "5cfeec75-f6e2-439c-946d-5317334cdc6c"
+        ],
+        "recording_mbid": "9ed38583-437f-4186-8183-9c31ffa2c116",
+        "release": "Syreeta",
+        "release_mbid": "5f7853be-1f7a-4850-b0b8-2333d6b0318f",
+        "title": "She's Leaving Home"
+    }
+]


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MessyBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
We have script to fetch artist MBIDs from MusicBrainz database now we need to create clusters using
those artist MBIDs.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-381](https://tickets.metabrainz.org/browse/LB-381)

# Action
Added functionality to create clusters using fetched artist MBIDs.
recording_artist_join table is joined with recording_json on equal recording MBID.
And a little modification on how entity MBIDs and gids are fetched is created in four new functions.
After that passed those functions to clustering functions in db_common.py to create clusters.
