### PR TITLE
LB-382: MessyBrainz: Create clusters using fetched release MBIDs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,13 @@ will be needed. This can be done using the following command:
 Keep in mind that this process is very time consuming, so make sure that you don't delete the ``data/mbdata`` directory accidently. Also make sure that you have about 25GB of free space to keep the MusicBrainz data.
 
 
-Now in order to initialize the database (create user, tables etc.) run these commands
+Now in order to initialize the database (create user, tables etc.) run this command
 
     $ docker-compose -f docker/docker-compose.yml -p messybrainz run --rm web bash -c "python3 manage.py init_db"
+
+Now in order to initialize the test database (create user, tables etc.) run this command
+
+    $ docker-compose -f docker/docker-compose.yml -p messybrainz run --rm web bash -c "python3 manage.py init_test_db"
 
 Then, in order to download all the software and build and start the containers needed to run
 MessyBrainz, run the following command.

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -33,6 +33,7 @@ CREATE INDEX recording_mbid_ndx_recording_json ON recording_json ((data ->> 'rec
 CREATE INDEX artist_mbid_ndx_recording_json ON recording_json ((data ->> 'artist_mbids'));
 CREATE INDEX release_mbid_ndx_recording_json ON recording_json ((data ->> 'release_mbid'));
 CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array(data -> 'artist_mbids'));
+CREATE INDEX release_name_ndx_recording_json ON recording_json ((data ->> 'release'));
 
 CREATE INDEX artist_ndx_recording ON recording (artist);
 CREATE INDEX release_ndx_recording ON recording (release);

--- a/manage.py
+++ b/manage.py
@@ -98,9 +98,8 @@ def init_test_db(force=False):
     if not exit_code:
         raise Exception('Failed to create new database and user! Exit code: %i' % exit_code)
 
+    print('Creating database extensions...')
     exit_code = db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'create_extensions.sql'))
-    if not exit_code:
-        raise Exception('Failed to create database extensions! Exit code: %i' % exit_code)
 
     db.init_db_engine(config.TEST_SQLALCHEMY_DATABASE_URI)
 

--- a/manage.py
+++ b/manage.py
@@ -207,29 +207,30 @@ def create_artist_credit_clusters_for_mbids(verbose='WARNING'):
 
 
 @cli.command()
-@click.option("--verbose", "-v", default=0, help="Print debug information for given verbose level(0,1,2).")
-def create_release_clusters_for_mbids(verbose=0):
+@click.option("--verbose", "-v", is_flag=True, help="Print debug information if verbose is turned on.")
+def create_release_clusters_for_mbids(verbose=False):
     """Creates clusters for release using release MBIDs present in
        recording_json table.
     """
 
-    if verbose == 1:
-        logging.basicConfig(format='%(message)s', level=logging.INFO)
-    elif verbose == 2:
+    if verbose:
         logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+    else:
+        logging.basicConfig(format='%(message)s', level=logging.INFO)
 
-    print("Creating release clusters...")
+    logging.info("Creating release clusters...")
 
-    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
     try:
+        db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+        musicbrainz_db.init_db_engine(config.MB_DATABASE_URI)
         logging.info("=" * 80)
         clusters_modified, clusters_add_to_redirect = release.create_release_clusters()
         logging.info("=" * 80)
-        print("Clusters modified: {0}.".format(clusters_modified))
-        print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
-        print ("Done!")
+        logging.info("Clusters modified: {0}.".format(clusters_modified))
+        logging.info("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
+        logging.info("Done!")
     except Exception as error:
-        print("While creating release clusters. An error occured: {0}".format(error))
+        logging.info("While creating release clusters. An error occured: {0}".format(error))
         raise
 
 
@@ -253,8 +254,9 @@ def truncate_artist_credit_cluster_and_redirect():
 @cli.command()
 def truncate_release_cluster_and_redirect():
     """Truncate release_cluster and release_redirect tables."""
-    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+
     try:
+        db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
         release.truncate_release_cluster_and_release_redirect_table()
         print("release_cluster and release_redirect table truncated.")
     except Exception as error:

--- a/manage.py
+++ b/manage.py
@@ -305,31 +305,54 @@ def truncate_recording_release_join_table():
 
 
 @cli.command()
-@click.option("--verbose", "-v", default="WARNING", help="Print debug information for given verbose level(WARNING, INFO, DEBUG).")
-def create_clusters_using_fetched_artist_mbids(verbose="WARNING"):
+@click.option("--verbose", "-v", is_flag=True, help="Print debug information.")
+def create_clusters_using_fetched_artist_mbids(verbose=False):
     """Creates clusters for artist_credits using artist MBIDs fetched from MusicBrainz
        database and stored in recording_artist_join table.
     """
 
-    try:
-        if verbose == "INFO":
-            logging.basicConfig(format='%(message)s', level=logging.INFO)
-        elif verbose == "DEBUG":
-            logging.basicConfig(format='%(message)s', level=logging.DEBUG)
-        elif verbose != "WARNING":
-            print("Invalid logging level specified. Using default logging level(WARNING).")
+    if verbose:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+    else:
+        logging.basicConfig(format='%(message)s', level=logging.INFO)
 
-        print("Creating artist_credit clusters...")
+    try:
+        logging.info("Creating artist_credit clusters...")
         db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
 
         logging.debug("=" * 80)
         clusters_modified, clusters_add_to_redirect = artist.create_clusters_using_fetched_artist_mbids()
         logging.debug("=" * 80)
-        print("Clusters modified: {0}.".format(clusters_modified))
-        print("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
-        print("Done!")
+        logging.info("Clusters modified: {0}.".format(clusters_modified))
+        logging.info("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
+        logging.info("Done!")
     except Exception as error:
-        print("While creating artist_credit clusters using fetched artist MBIDs. An error occured: {0}".format(error))
+        logging.info("While creating artist_credit clusters using fetched artist MBIDs. An error occured: {0}".format(error))
+
+
+@click.option("--verbose", "-v", is_flag=True, help="Print debug information.")
+def create_clusters_using_fetched_releases(verbose=False):
+    """Creates clusters for releases using releases fetched from MusicBrainz
+       database and stored in recording_release_join table.
+    """
+
+    if verbose:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+    else:
+        logging.basicConfig(format='%(message)s', level=logging.INFO)
+
+    try:
+        logging.info("Creating release clusters...")
+        db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+
+        logging.debug("=" * 80)
+        clusters_modified, clusters_add_to_redirect = release.create_clusters_using_fetched_releases()
+        logging.debug("=" * 80)
+        logging.info("Clusters modified: {0}.".format(clusters_modified))
+        logging.info("Clusters add to redirect table: {0}.".format(clusters_add_to_redirect))
+        logging.info("Done!")
+    except Exception as error:
+        logging.info("While creating release clusters using fetched releases. An error occured: {0}".format(error))
 
 
 if __name__ == '__main__':

--- a/manage.py
+++ b/manage.py
@@ -332,6 +332,7 @@ def create_clusters_using_fetched_artist_mbids(verbose=False):
         logging.info("While creating artist_credit clusters using fetched artist MBIDs. An error occured: {0}".format(error))
 
 
+@cli.command()
 @click.option("--verbose", "-v", is_flag=True, help="Print debug information.")
 def create_clusters_using_fetched_releases(verbose=False):
     """Creates clusters for releases using releases fetched from MusicBrainz

--- a/messybrainz/db/release.py
+++ b/messybrainz/db/release.py
@@ -93,6 +93,7 @@ def fetch_unclustered_distinct_release_mbids(connection):
               LEFT JOIN release_cluster AS relc
                      ON rec.release = relc.release_gid
                   WHERE recj.data ->> 'release_mbid' IS NOT NULL
+                    AND recj.data ->> 'release_mbid' != ''
                     AND relc.release_gid IS NULL
     """))
 
@@ -163,7 +164,7 @@ def fetch_release_left_to_cluster(connection):
                    JOIN recording_json AS recj
                      ON rec.data = recj.id
               LEFT JOIN release_redirect AS relr
-                     ON (recj.data ->> 'release_mbid')::uuid = relr.release_mbid
+                     ON (recj.data ->> 'release_mbid') = (relr.release_mbid)::text
                   WHERE recj.data ->> 'release_mbid' IS NOT NULL
                     AND relr.release_mbid IS NULL
     """))
@@ -329,7 +330,7 @@ def fetch_recording_mbids_not_in_recording_release_join(connection):
         SELECT DISTINCT recj.data ->> 'recording_mbid'
                    FROM recording_json AS recj
               LEFT JOIN recording_release_join AS rrj
-                     ON (recj.data ->> 'recording_mbid')::uuid = rrj.recording_mbid
+                     ON recj.data ->> 'recording_mbid' = (rrj.recording_mbid)::text
                   WHERE recj.data ->> 'recording_mbid' IS NOT NULL
                     AND rrj.recording_mbid IS NULL
     """))
@@ -414,7 +415,7 @@ def fetch_unclustered_release_mbids_using_recording_release_join(connection):
         SELECT DISTINCT rrj.release_mbid
                    FROM recording_release_join AS rrj
                    JOIN recording_json AS recj
-                     ON rrj.recording_mbid = (recj.data ->> 'recording_mbid')::uuid
+                     ON (rrj.recording_mbid)::text = recj.data ->> 'recording_mbid'
                     AND rrj.release_name = (recj.data ->> 'release')
                    JOIN recording AS rec
                      ON rec.data = recj.id
@@ -442,7 +443,7 @@ def fetch_unclustered_gids_for_release_using_recording_release_join(connection, 
         SELECT DISTINCT rec.release
                    FROM recording_json AS recj
                    JOIN recording_release_join AS rrj
-                     ON rrj.recording_mbid = (recj.data ->> 'recording_mbid')::uuid
+                     ON recj.data ->> 'recording_mbid' = (rrj.recording_mbid)::text
                     AND rrj.release_name = (recj.data ->> 'release')
                    JOIN recording AS rec
                      ON recj.id = rec.data
@@ -474,7 +475,7 @@ def fetch_release_left_to_cluster_using_recording_release_join(connection):
                    JOIN recording_json AS recj
                      ON rec.data = recj.id
                    JOIN recording_release_join AS rrj
-                     ON rrj.recording_mbid = (recj.data ->> 'recording_mbid')::uuid
+                     ON recj.data ->> 'recording_mbid' = (rrj.recording_mbid)::text
                     AND rrj.release_name = (recj.data ->> 'release')
               LEFT JOIN release_redirect AS relr
                      ON rrj.release_mbid = relr.release_mbid
@@ -499,7 +500,7 @@ def get_release_gids_from_recording_using_fetched_releases(connection, release_m
                    JOIN recording_json AS recj
                      ON rec.data = recj.id
                    JOIN recording_release_join AS rrj
-                     ON rrj.recording_mbid = (recj.data ->> 'recording_mbid')::uuid
+                     ON recj.data ->> 'recording_mbid' = (rrj.recording_mbid)::text
                     AND rrj.release_name = (recj.data ->> 'release')
                   WHERE rrj.release_mbid = :release_mbid
     """), {
@@ -515,12 +516,12 @@ def get_recordings_metadata_using_recording_release_join(connection, release_mbi
     """
 
     recordings = connection.execute(text("""
-            SELECT recj.data
+          SELECT recj.data
             FROM recording_json AS recj
             JOIN recording_release_join AS rrj
-              ON rrj.recording_mbid = (recj.data ->> 'recording_mbid')::uuid
+              ON recj.data ->> 'recording_mbid' = (rrj.recording_mbid)::text
              AND rrj.release_name = (recj.data ->> 'release')
-            WHERE rrj.release_mbid = :mbid
+           WHERE rrj.release_mbid = :mbid
         """), {
             "mbid": release_mbid,
         })

--- a/messybrainz/db/tests/test_release.py
+++ b/messybrainz/db/tests/test_release.py
@@ -51,6 +51,51 @@ class ReleaseTestCase(DatabaseTestCase):
         return msb_listens
 
 
+    def _add_data_to_recording_release_join(self):
+        """ Adds releases to recording_release_join table for recording MBIDs."""
+
+        recording_mbids_submitted = ["4a9818ba-5963-4761-864f-7d96841053d2",
+            "2977432b-f1a2-4c37-b60f-bac1ce4e0961",
+            "5465ca86-3881-4349-81b2-6efbd3a59451",
+        ]
+
+        releases_fetched = [
+            [
+                {'id': '6e18c5c8-e487-4f83-9ea6-281c574933b9', 'name': 'The Blueprint 3'},
+                {'id': '2829f1bc-b097-31f3-9fbc-00b4f7228a52', 'name': 'The Blueprint 3'},
+                {'id': '95ff991b-7af3-42bb-9979-470ec2bd3741', 'name': 'The Blueprint 3 [Soul Assassin Special Edition]'},
+                {'id': '5e782ae3-602b-48b7-99be-de6bcffa4aba', 'name': 'The Hits Collection, Volume 1'},
+                {'id': '0996e292-5cb4-476b-be04-640eeecca646', 'name': 'The Blueprint 3'},
+                {'id': '7ebaaa95-e316-3b20-8819-7e4ca648c135', 'name': 'The Hits Collection, Volume 1'},
+                {'id': '74465497-af1a-40f2-8998-3f837a8d29ba', 'name': 'The Blueprint 3'},
+                {'id': '5b94f201-0343-4728-a851-05f5abff2495', 'name': 'The Blueprint 3'},
+                {'id': '4a441628-2e4d-4032-825f-6bdf4aee382e', 'name': 'The Hits Collection, Volume 1'}
+            ],
+            [
+                {'id': '8f0c9315-6f65-4098-98a8-765e447c6d78', 'name': "Wouldn't You Like to..."}
+            ],
+            [
+                {'id': 'f1183a86-36d2-4f1f-ab8f-6f965dc0b033', 'name': 'The Hits Collection Volume One'},
+                {'id': '7111c8bc-8549-4abc-8ab9-db13f65b4a55', 'name': 'Blueprint 2.1'},
+                {'id': '3c535d03-2fcc-467a-8d47-34b3250b8211', 'name': 'The Hits Collection Volume One'},
+                {'id': '0ff452e3-c306-4082-b0dc-223725f4fbbf', 'name': 'The Blueprint²: The Gift & The Curse'},
+                {'id': '801678aa-5d30-4342-8227-e9618f164cca', 'name': 'The Blueprint²: The Gift & The Curse'},
+                {'id': '5e782ae3-602b-48b7-99be-de6bcffa4aba', 'name': 'The Hits Collection, Volume 1'},
+                {'id': '4f41108c-db36-4616-8614-f504fdef287a', 'name': 'Blueprint 2.1'},
+                {'id': '89f64145-2f75-41d1-831a-517b785ed75a', 'name': "The Blueprint Collector's Edition"},
+                {'id': '7ebaaa95-e316-3b20-8819-7e4ca648c135', 'name': 'The Hits Collection, Volume 1'},
+                {'id': '77a74b85-0ae0-338f-aaca-4f36cd394f88', 'name': 'Blueprint 2.1'},
+                {'id': 'd75e103c-5ef4-4146-ae81-e27d19dc7fc4', 'name': "The Blueprint Collector's Edition"},
+                {'id': '2c5e4198-24cf-3c95-a16e-83be8e877dfa', 'name': 'The Blueprint²: The Gift & The Curse'},
+                {'id': '4a441628-2e4d-4032-825f-6bdf4aee382e', 'name': 'The Hits Collection, Volume 1'}
+            ]
+        ]
+
+        with db.engine.begin() as connection:
+            for recording_mbid, releases in zip(recording_mbids_submitted, releases_fetched):
+                release.insert_releases_to_recording_release_join(connection, recording_mbid, releases)
+
+
     def test_fetch_unclustered_distinct_release_mbids(self):
         """Tests if release_mbids are correctly fetched from recording_json table."""
 
@@ -641,3 +686,284 @@ class ReleaseTestCase(DatabaseTestCase):
             release.fetch_and_store_releases_for_all_recording_mbids()
             releases = release.get_releases_for_recording_mbid(connection, "9ed38583-437f-4186-8183-9c31ffa2c116")
             self.assertSetEqual(set(releases), set(releases_fetched[3]))
+
+
+    def test_fetch_unclustered_release_mbids_using_recording_release_join(self):
+        """Tests if release mbids are fetched correctly."""
+
+        msb_listens = self._load_test_data("recordings_for_clustering_using_fetched_releases.json")
+        submit_listens(msb_listens)
+
+        self._add_data_to_recording_release_join()
+
+        with db.engine.begin() as connection:
+            releases_fetched = release.fetch_unclustered_release_mbids_using_recording_release_join(connection)
+            self.assertSetEqual(set(releases_fetched), set([
+                UUID("7ebaaa95-e316-3b20-8819-7e4ca648c135"),
+                UUID("5b94f201-0343-4728-a851-05f5abff2495"),
+                UUID("6e18c5c8-e487-4f83-9ea6-281c574933b9"),
+                UUID("77a74b85-0ae0-338f-aaca-4f36cd394f88"),
+                UUID("2829f1bc-b097-31f3-9fbc-00b4f7228a52"),
+                UUID("5e782ae3-602b-48b7-99be-de6bcffa4aba"),
+                UUID("0ff452e3-c306-4082-b0dc-223725f4fbbf"),
+                UUID("74465497-af1a-40f2-8998-3f837a8d29ba"),
+                UUID("0996e292-5cb4-476b-be04-640eeecca646"),
+                UUID("2c5e4198-24cf-3c95-a16e-83be8e877dfa"),
+                UUID("4a441628-2e4d-4032-825f-6bdf4aee382e"),
+                UUID("801678aa-5d30-4342-8227-e9618f164cca"),
+                UUID("4f41108c-db36-4616-8614-f504fdef287a"),
+                UUID("7111c8bc-8549-4abc-8ab9-db13f65b4a55"),
+                UUID('8f0c9315-6f65-4098-98a8-765e447c6d78'),
+            ]))
+
+
+    def test_fetch_unclustered_gids_for_release_using_recording_release_join(self):
+        """ Tests if unclustered gids are fetched correctly using
+            recording_release_join table.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_clustering_using_fetched_releases.json")
+        submit_listens(msb_listens)
+        self._add_data_to_recording_release_join()
+
+        with db.engine.begin() as connection:
+            gids = release.fetch_unclustered_gids_for_release_using_recording_release_join(connection,
+                        UUID("7ebaaa95-e316-3b20-8819-7e4ca648c135")
+                    )
+            gids_from_data = UUID(data.get_release(connection, "The Hits Collection, Volume 1"))
+            self.assertListEqual(gids, [gids_from_data])
+
+
+    def test_fetch_release_left_to_cluster_using_recording_release_join(self):
+        """ Tests if releases left to cluster are correctly fetched using
+            recording_release_join table.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_clustering_using_fetched_releases.json")
+        submit_listens(msb_listens)
+        self._add_data_to_recording_release_join()
+
+        with db.engine.begin() as connection:
+            release.create_clusters_using_fetched_releases_without_anomalies(connection)
+
+            release_left = release.fetch_release_left_to_cluster_using_recording_release_join(connection)
+            self.assertSetEqual(set(release_left), set([
+                UUID('4a441628-2e4d-4032-825f-6bdf4aee382e'),
+                UUID('6e18c5c8-e487-4f83-9ea6-281c574933b9'),
+                UUID('801678aa-5d30-4342-8227-e9618f164cca'),
+                UUID('4f41108c-db36-4616-8614-f504fdef287a'),
+                UUID('2829f1bc-b097-31f3-9fbc-00b4f7228a52'),
+                UUID('7111c8bc-8549-4abc-8ab9-db13f65b4a55'),
+                UUID('5e782ae3-602b-48b7-99be-de6bcffa4aba'),
+                UUID('74465497-af1a-40f2-8998-3f837a8d29ba'),
+                UUID('0996e292-5cb4-476b-be04-640eeecca646'),
+                UUID('2c5e4198-24cf-3c95-a16e-83be8e877dfa')
+            ]))
+
+    def test_get_release_gids_from_recording_using_fetched_releases(self):
+        """ Tests if release gids are fetched correctly from recording table
+            using fetched releases stored in recoring_release_join table.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_clustering_using_fetched_releases.json")
+        submit_listens(msb_listens)
+        self._add_data_to_recording_release_join()
+
+        with db.engine.begin() as connection:
+            gids = release.get_release_gids_from_recording_using_fetched_releases(connection,
+                UUID('4a441628-2e4d-4032-825f-6bdf4aee382e')
+            )
+            gids_from_data = UUID(data.get_release(connection, "The Hits Collection, Volume 1"))
+            self.assertListEqual(gids, [gids_from_data])
+
+
+    def test_get_recordings_metadata_using_recording_release_join(self):
+        """ Tests if recordings metadata is fetched correctly using release MBID
+            and join on recording_release_join table.
+        """
+
+        recording_1 = {
+            "artist": "Jay‐Z & Beyoncé",
+            "title": "'03 Bonnie & Clyde",
+            "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451",
+            "release": "The Blueprint²: The Gift & The Curse",
+        }
+        submit_listens([recording_1])
+        self._add_data_to_recording_release_join()
+        
+        with db.engine.begin() as connection:
+            recordings = release.get_recordings_metadata_using_recording_release_join(connection, "0ff452e3-c306-4082-b0dc-223725f4fbbf")
+            self.assertDictEqual(recording_1, recordings[0])
+
+
+    def test_create_clusters_using_fetched_releases_without_anomalies(self):
+        """ Tests if clusters are correctly formed using fetched releases without
+            considering anomalies.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_clustering_using_fetched_releases.json")
+        submit_listens(msb_listens)
+        self._add_data_to_recording_release_join()
+
+        with db.engine.begin() as connection:
+            clusters_modified, clusters_add_to_redirect = release.create_clusters_using_fetched_releases_without_anomalies(connection)
+            self.assertEqual(clusters_modified, 5)
+            self.assertEqual(clusters_add_to_redirect, 5)
+
+            # "Wouldn't You Like to..." forms one cluster
+            gid_from_data = UUID(data.get_release(connection, "Wouldn't You Like to..."))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("8f0c9315-6f65-4098-98a8-765e447c6d78")])
+
+            # "The Blueprint 3" with MBID "5b94f201-0343-4728-a851-05f5abff2495" gets clustered
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint 3"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("5b94f201-0343-4728-a851-05f5abff2495")])
+
+            # "The Hits Collection, Volume 1" with MBID "7ebaaa95-e316-3b20-8819-7e4ca648c135" gets clustered
+            gid_from_data = UUID(data.get_release(connection, "The Hits Collection, Volume 1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("7ebaaa95-e316-3b20-8819-7e4ca648c135")])
+
+            # "The Blueprint²: The Gift & The Curse" with MBID "0ff452e3-c306-4082-b0dc-223725f4fbbf" gets clustered
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint²: The Gift & The Curse"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("0ff452e3-c306-4082-b0dc-223725f4fbbf")])
+
+            # "Blueprint 2.1" with MBID "77a74b85-0ae0-338f-aaca-4f36cd394f88" gets clustered
+            gid_from_data = UUID(data.get_release(connection, "Blueprint 2.1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("77a74b85-0ae0-338f-aaca-4f36cd394f88")])
+
+
+    def test_create_clusters_using_fetched_releases_for_anomalies(self):
+        """ Tests if clusters are correctly formed for anomalies using
+            recording_release_join table.
+        """
+
+        msb_listens = self._load_test_data("recordings_for_clustering_using_fetched_releases.json")
+        submit_listens(msb_listens)
+        self._add_data_to_recording_release_join()
+
+        with db.engine.begin() as connection:
+            clusters_modified, clusters_add_to_redirect = release.create_clusters_using_fetched_releases_without_anomalies(connection)
+            self.assertEqual(clusters_modified, 5)
+            self.assertEqual(clusters_add_to_redirect, 5)
+
+            # Before clustering anomalies we get the following clusters
+            # "The Blueprint 3" with MBID "5b94f201-0343-4728-a851-05f5abff2495" gets clustered
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint 3"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("5b94f201-0343-4728-a851-05f5abff2495")])
+
+            # "The Hits Collection, Volume 1" with MBID "7ebaaa95-e316-3b20-8819-7e4ca648c135" gets clustered
+            gid_from_data = UUID(data.get_release(connection, "The Hits Collection, Volume 1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("7ebaaa95-e316-3b20-8819-7e4ca648c135")])
+
+            # "The Blueprint²: The Gift & The Curse" with MBID "0ff452e3-c306-4082-b0dc-223725f4fbbf" gets clustered
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint²: The Gift & The Curse"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("0ff452e3-c306-4082-b0dc-223725f4fbbf")])
+
+            # "Blueprint 2.1" with MBID "77a74b85-0ae0-338f-aaca-4f36cd394f88" gets clustered
+            gid_from_data = UUID(data.get_release(connection, "Blueprint 2.1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("77a74b85-0ae0-338f-aaca-4f36cd394f88")])
+
+            clusters_add_to_redirect = release.create_clusters_using_fetched_releases_for_anomalies(connection)
+            self.assertEqual(clusters_add_to_redirect, 10)
+
+            # Other unclustered MBIDs for "The Blueprint 3" get added into release_redirect table.
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint 3"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertSetEqual(set(release_mbids), set([
+                UUID('5b94f201-0343-4728-a851-05f5abff2495'),
+                UUID('6e18c5c8-e487-4f83-9ea6-281c574933b9'),
+                UUID('2829f1bc-b097-31f3-9fbc-00b4f7228a52'),
+                UUID('74465497-af1a-40f2-8998-3f837a8d29ba'),
+                UUID('0996e292-5cb4-476b-be04-640eeecca646')
+            ]))
+
+            # Other unclustered MBIDs for "The Hits Collection, Volume 1" get added into release_redirect table.
+            gid_from_data = UUID(data.get_release(connection, "The Hits Collection, Volume 1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertSetEqual(set(release_mbids), set([
+                UUID('7ebaaa95-e316-3b20-8819-7e4ca648c135'),
+                UUID('4a441628-2e4d-4032-825f-6bdf4aee382e'),
+                UUID('5e782ae3-602b-48b7-99be-de6bcffa4aba')
+            ]))
+
+            # Other unclustered MBIDs for "The Blueprint²: The Gift & The Curse" get added into release_redirect table.
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint²: The Gift & The Curse"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertSetEqual(set(release_mbids), set([
+                UUID('0ff452e3-c306-4082-b0dc-223725f4fbbf'),
+                UUID('801678aa-5d30-4342-8227-e9618f164cca'),
+                UUID('2c5e4198-24cf-3c95-a16e-83be8e877dfa')
+            ]))
+
+            # Other unclustered MBIDs for "Blueprint 2.1" get added into release_redirect table.
+            gid_from_data = UUID(data.get_release(connection, "Blueprint 2.1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertSetEqual(set(release_mbids), set([
+                UUID('77a74b85-0ae0-338f-aaca-4f36cd394f88'),
+                UUID('4f41108c-db36-4616-8614-f504fdef287a'),
+                UUID('7111c8bc-8549-4abc-8ab9-db13f65b4a55')
+            ]))
+
+
+    def test_create_clusters_using_fetched_releases(self):
+        """ Tests if clusters are created correctly using fetched releases. """
+
+        msb_listens = self._load_test_data("recordings_for_clustering_using_fetched_releases.json")
+        submit_listens(msb_listens)
+        self._add_data_to_recording_release_join()
+
+        with db.engine.begin() as connection:
+            clusters_modified, clusters_add_to_redirect = release.create_clusters_using_fetched_releases()
+            self.assertEqual(clusters_modified, 5)
+            self.assertEqual(clusters_add_to_redirect, 15)
+
+            # "Wouldn't You Like to..." forms one cluster
+            gid_from_data = UUID(data.get_release(connection, "Wouldn't You Like to..."))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertListEqual(release_mbids, [UUID("8f0c9315-6f65-4098-98a8-765e447c6d78")])
+
+            # "The Blueprint 3" forms one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint 3"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertSetEqual(set(release_mbids), set([
+                UUID('5b94f201-0343-4728-a851-05f5abff2495'),
+                UUID('6e18c5c8-e487-4f83-9ea6-281c574933b9'),
+                UUID('2829f1bc-b097-31f3-9fbc-00b4f7228a52'),
+                UUID('74465497-af1a-40f2-8998-3f837a8d29ba'),
+                UUID('0996e292-5cb4-476b-be04-640eeecca646')
+            ]))
+
+            # "The Hits Collection, Volume 1" forms one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Hits Collection, Volume 1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertSetEqual(set(release_mbids), set([
+                UUID('7ebaaa95-e316-3b20-8819-7e4ca648c135'),
+                UUID('4a441628-2e4d-4032-825f-6bdf4aee382e'),
+                UUID('5e782ae3-602b-48b7-99be-de6bcffa4aba')
+            ]))
+
+            # "The Blueprint²: The Gift & The Curse" forms one cluster
+            gid_from_data = UUID(data.get_release(connection, "The Blueprint²: The Gift & The Curse"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertSetEqual(set(release_mbids), set([
+                UUID('0ff452e3-c306-4082-b0dc-223725f4fbbf'),
+                UUID('801678aa-5d30-4342-8227-e9618f164cca'),
+                UUID('2c5e4198-24cf-3c95-a16e-83be8e877dfa')
+            ]))
+
+            # "Blueprint 2.1" forms one cluster
+            gid_from_data = UUID(data.get_release(connection, "Blueprint 2.1"))
+            release_mbids = get_release_mbids_using_msid(connection, gid_from_data)
+            self.assertSetEqual(set(release_mbids), set([
+                UUID('77a74b85-0ae0-338f-aaca-4f36cd394f88'),
+                UUID('4f41108c-db36-4616-8614-f504fdef287a'),
+                UUID('7111c8bc-8549-4abc-8ab9-db13f65b4a55')
+            ]))

--- a/messybrainz/testdata/recordings_for_clustering_using_fetched_releases.json
+++ b/messybrainz/testdata/recordings_for_clustering_using_fetched_releases.json
@@ -1,0 +1,38 @@
+[
+    {
+        "title": "Empire State of Mind",
+        "artist": "Jay‐Z + Alicia Keys",
+        "release": "The Blueprint 3",
+        "recording_mbid": "4a9818ba-5963-4761-864f-7d96841053d2"
+    },
+    {
+        "title": "Empire State of Mind",
+        "artist": "Jay‐Z + Alicia Keys",
+        "release": "The Hits Collection, Volume 1",
+        "recording_mbid": "4a9818ba-5963-4761-864f-7d96841053d2"
+    },
+    {
+        "title": "Wouldn't You Like to... (radio edit) (feat. Kanye West & Common)",
+        "artist": "Malik Yusef",
+        "release": "Wouldn't You Like to...",
+        "recording_mbid": "2977432b-f1a2-4c37-b60f-bac1ce4e0961"
+    },
+    {
+        "title": "'03 Bonnie and Clyde",
+        "artist": "Jay‐Z & Beyoncé",
+        "release": "The Blueprint²: The Gift & The Curse",
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451"
+    },
+    {
+        "title": "'03 Bonnie and Clyde",
+        "artist": "Jay‐Z & Beyoncé",
+        "release": "The Blueprint²: The Gift and The Curse",
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451"
+    },
+    {
+        "title": "'03 Bonnie and Clyde",
+        "artist": "Jay‐Z & Beyoncé",
+        "release": "Blueprint 2.1",
+        "recording_mbid": "5465ca86-3881-4349-81b2-6efbd3a59451"
+    }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/metabrainz/brainzutils-python.git@v1.5.1
+git+https://github.com/kartikeyaSh/brainzutils-python.git@b928bbac881e7a1c929f4700e53bb4e3d96a0b51
 Fabric == 1.10.2
 Flask-Testing == 0.4.2
 Flask-SQLAlchemy==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ ujson==1.33
 pytest==3.3.1
 pytest-cov==2.5.1
 unittest2==1.1.0
+tabulate==0.8.3

--- a/test_clustering_manually.py
+++ b/test_clustering_manually.py
@@ -1,0 +1,297 @@
+import json
+import logging
+import messybrainz
+import os
+import tabulate
+import uuid
+
+import messybrainz.default_config as config
+try:
+    import messybraiz.custom_config as config
+except ImportError:
+    pass
+
+from brainzutils import musicbrainz_db
+from messybrainz import db
+from messybrainz.db import release as db_release
+from sqlalchemy import text
+
+ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "admin", "sql")
+
+# Limit the output of table content to 50 rows, so that we don't end up
+# having too much verbose. Can use custom command if complete output is required.
+LIMIT = 50
+
+FUNCTIONS = {
+    "1": db_release.create_clusters_using_fetched_releases,
+    "2": db_release.fetch_and_store_releases_for_all_recording_mbids,
+}
+
+
+def submit_listens(listens):
+    """Submits listens to the MessyBrainz database."""
+
+    msb_listens = []
+    for listen in listens:
+        messy_dict = {
+            "artist": listen["artist"],
+            "title": listen["title"],
+        }
+        if "release" in listen:
+            messy_dict["release"] = listen["release"]
+
+        if "artist_mbids" in listen:
+            messy_dict["artist_mbids"] = listen["artist_mbids"]
+        if "release_mbid" in listen:
+            messy_dict["release_mbid"] = listen["release_mbid"]
+        if "recording_mbid" in listen:
+            messy_dict["recording_mbid"] = listen["recording_mbid"]
+        msb_listens.append(messy_dict)
+
+    messybrainz.submit_listens_and_sing_me_a_sweet_song(msb_listens)
+
+
+# lifted from AcousticBrainz
+def is_valid_uuid(u):
+    try:
+        u = uuid.UUID(u)
+        return True
+    except ValueError:
+        return False
+
+
+def submit_using_json():
+    """Submits listens from a give JSON file."""
+
+    filename = input("Enter path to the JSON file: ")
+    with open(filename) as f:
+        listens = json.load(f)
+        submit_listens(listens)
+        print("Done!")
+
+
+def manually_submit_listens():
+    """Allows user to manually insert data into database."""
+
+    while True:
+        print("Note: you can't leave 'artist_credit', 'recording' empty.")
+        artist = input("artist_credit: ")
+        while artist == "":
+            print("Invalid artist_credit. Try again.")
+            artist = input("artist_credit: ")
+        title = input("recording: ")
+        while title == "":
+            print("Invalid recording. Try again.")
+            title = input("recording: ")
+        release = input("release: ")
+        recording_mbid = input("recording_mbid: ")
+        while recording_mbid != "" and not is_valid_uuid(recording_mbid):
+            print("Invalid UUID inserted. Try again.")
+            recording_mbid = input("recording_mbid: ")
+
+        artist_mbids = []
+        while True:
+            print("Enter artist MBIDs one per line (empty line to end): ")
+            artist_mbid = input()
+            if(artist_mbid ==""):
+                break
+            if not is_valid_uuid(artist_mbid):
+                print("Invalid UUIDs inserted. Try again.")
+                continue
+            artist_mbids.append(artist_mbid)
+
+        release_mbid = input("release_mbid: ")
+        while release_mbid != "" and not is_valid_uuid(release_mbid):
+            print("Invalid UUID inserted. Try again.")
+            release_mbid = input("release_mbid: ")
+
+        msb_listen = {"artist": artist, "title": title}
+        if release != "":
+            msb_listen["release"] = release
+        if recording_mbid != "":
+            msb_listen["recording_mbid"] = recording_mbid
+        if artist_mbids != "":
+            msb_listen["artist_mbids"] = artist_mbids
+        if release_mbid != "":
+            msb_listen["release_mbid"] = release_mbid
+
+        submit_listens([msb_listen])
+        print("Done!")
+
+        more = input("Do you want to add more listens(y/n): ")
+        if more in ["n", "N", "no", "NO", "No"]:
+            break
+
+
+def add_listens():
+    """Allow user to add data to the database with different options."""
+
+    while True:
+        input_method = input("Select input method you want to use to submit listens:"
+                            "\n0) Go back."
+                            "\n1) From JSON file."
+                            "\n2) Manually add data.\n"
+                        )
+        if input_method == "0":
+            break
+        elif input_method == "1":
+            submit_using_json()
+        elif input_method == "2":
+            manually_submit_listens()
+        else:
+            print("Enter valid input_method. Try again.")
+
+
+def reset_db():
+    """Resets the database."""
+
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, "drop_tables.sql"))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, "create_tables.sql"))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, "create_primary_keys.sql"))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, "create_foreign_keys.sql"))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, "create_functions.sql"))
+    db.run_sql_script(os.path.join(ADMIN_SQL_DIR, "create_indexes.sql"))
+    print("Database reset done.")
+
+
+def truncate_table():
+    """Utility to truncate any table from the database."""
+
+    while True:
+        table_name = input("Enter table name to truncate ('0' to go back): ")
+        if table_name == "0":
+            break
+        with db.engine.begin() as connection:
+            # This is insecure, but here we are doing it on test_db. So, we can take this risk.
+            connection.execute(text("""TRUNCATE TABLE {0} CASCADE""".format(table_name)))
+            print("{0} truncated.".format(table_name))
+
+
+def print_table():
+    """Prints the contents of the table user enters. Limits the number of rows to 50."""
+
+    while True:
+        table_name = input("Enter table name to print ('0' to go back): ")
+        if table_name == "0":
+            break
+        with db.engine.begin() as connection:
+            # This is insecure, but here we are doing it on test_db. So, we can take this risk.
+            result = connection.execute(text("""SELECT * FROM {0} LIMIT {1}""".format(table_name, LIMIT)))
+            headers = result.keys()
+            print(tabulate.tabulate(result, headers=headers, tablefmt="psql"))
+
+
+def run_script():
+    """Runs the script which user wants to test."""
+
+    while True:
+        to_run = input("Select option number:\n"
+                        "0) Go back\n"
+                        "1) create_clusters_using_fetched_releases\n"
+                        "2) fetch_and_store_releases_for_all_recording_mbids\n"
+                )
+        if to_run == "0":
+            break
+        if to_run not in FUNCTIONS:
+            print("Select valid option. Please try again.")
+            continue
+        else:
+            if to_run == "1":
+                FUNCTIONS["1"]()
+            elif to_run == "2":
+                FUNCTIONS["2"]()
+            print("Done!")
+
+
+def set_log_level():
+    """Sets the logging level which user desires."""
+
+    while True:
+        level_num = input("Enter logging level you want:\n"
+                    "0) Go back\n"
+                    "1) Debug\n"
+                    "2) Info\n"
+                    "3) Warning\n"
+                    )
+        if level_num not in [str(i) for i in range(0,4)]:
+            print("Enter valid option number.")
+            continue
+
+        logger_level = logging.NOTSET
+        if level_num == "0":
+            return
+        elif level_num == "1":
+            logger_level = logging.DEBUG
+        elif level_num == "2":
+            logger_level = logging.INFO
+        elif level_num == "3":
+            logger_level = logging.WARNING
+
+        logging.getLogger().setLevel(logger_level)
+        print("Logging level set to: {0}".format(logging.getLevelName(logger_level)))
+        break
+
+
+def run_custom_command():
+    """Runs custom SQL command entered by user on the database."""
+
+    while True:
+        command = input("Enter SQL command ('0' to go back): ")
+        if command == "0":
+            return
+        with db.engine.begin() as connection:
+            # This is insecure, but here we are doing it on test_db. So, we can take this risk.
+            result = connection.execute(text(command))
+            if result.returns_rows:
+                headers = result.keys()
+                print(tabulate.tabulate(result, headers=headers, tablefmt="psql"))
+
+
+def test_clustering_manually():
+    """Provides interface to an user to test clustering/fetching scripts."""
+
+    try:
+        db.init_db_engine(config.TEST_SQLALCHEMY_DATABASE_URI)
+        musicbrainz_db.init_db_engine(config.MB_DATABASE_URI)
+        logging.basicConfig(format="%(message)s")
+    except Exception as e:
+        print("While initializing database engine error occured: {0}".format(e))
+
+    while True:
+        option = input("Select option number:\n"
+                    "0) Exit\n"
+                    "1) Select script to run.\n"
+                    "2) Add more Listens.\n"
+                    "3) Reset database.\n"
+                    "4) Truncate table.\n"
+                    "5) Print table contents.\n"
+                    "6) Change logging level.\n"
+                    "7) Run custom SQL command.\n"
+                )
+
+        if(option not in [str(i) for i in range(0,8)]):
+            print("Invalid option number. Try again.")
+            continue
+        try:
+            if option == "0":
+                break
+            elif option == "1":
+                run_script()
+            elif option == "2":
+                add_listens()
+            elif option == "3":
+                reset_db()
+            elif option == "4":
+                truncate_table()
+            elif option == "5":
+                print_table()
+            elif option == "6":
+                set_log_level()
+            elif option == "7":
+                run_custom_command()
+        except Exception as e:
+            print("*" * 80)
+            print("\nSomething went wrong: {0}".format(e))
+            print("*" * 80)
+
+test_clustering_manually()


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MessyBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary
We have a lot of listens with recording MBIDs. So, using those MBIDs we can get release MBIDs which can be used to cluster releases.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

* JIRA ticket (_optional_): [LB-382](https://tickets.metabrainz.org/browse/LB-382)

# Action

Add functionality to create clusters using fetched releases.
recording_release_join table is joined with recording_json on equal recording MBID and release names.
And a little modification on how entity MBIDs and gids are fetched is created in four new functions.
After that passed those functions to clustering functions in db_common.py to create clusters.
