### PR TITLE
LB-384: MessyBrainz: Create a script to cluster incoming recordings.

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -20,7 +20,7 @@ CREATE TABLE artist_credit_redirect (
   artist_credit_cluster_id UUID NOT NULL, -- FK to artist_credit_cluster.cluster_id
   artist_mbids_array       UUID[] NOT NULL
 );
-ALTER TABLE artist_credit_redirect ADD CONSTRAINT artist_credit_redirect_artist_mbids_array_uniq UNIQUE (artist_mbids_array);
+ALTER TABLE artist_credit_redirect ADD CONSTRAINT artist_credit_redirect_uniq UNIQUE (artist_credit_cluster_id, artist_mbids_array);
 
 CREATE TABLE recording (
   id         SERIAL,

--- a/admin/sql/updates/2018-08-04-create-unique-constraint-on-artist-credit-redirect.sql
+++ b/admin/sql/updates/2018-08-04-create-unique-constraint-on-artist-credit-redirect.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE artist_credit_redirect ADD CONSTRAINT artist_credit_redirect_uniq UNIQUE (artist_credit_cluster_id, artist_mbids_array);
+
+COMMIT;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ version: "2"
 
 volumes:
   dbvolume:
+  rabbitmq:
 
 services:
 
@@ -21,6 +22,11 @@ services:
     volumes:
       - ./docker/data/redis:/data
 
+  rabbitmq:
+    image: rabbitmq:3.6.5
+    volumes:
+      - rabbitmq:/var/lib/rabbitmq:z
+
   web:
     build:
       context: ..
@@ -35,6 +41,7 @@ services:
       - db
       - musicbrainz_db
       - redis
+      - rabbitmq
 
   musicbrainz_db:
     image: metabrainz/musicbrainz-test-database:schema-change-2017-q2
@@ -45,3 +52,12 @@ services:
       MB_IMPORT_DUMPS: "true"
     ports:
       - "5430:5432"
+
+  cluster:
+    image: web
+    command: python3 -m "messybrainz.cluster.cluster"
+    volumes:
+      - ..:/code/listenbrainz:z
+    depends_on:
+      - db
+      - rabbitmq

--- a/messybrainz/__init__.py
+++ b/messybrainz/__init__.py
@@ -1,6 +1,7 @@
 from messybrainz.db import exceptions
 import sqlalchemy.exc
 from messybrainz.db import data
+from messybrainz.db import recording as db_recording
 
 from messybrainz import db
 
@@ -16,6 +17,8 @@ def submit_listens_and_sing_me_a_sweet_song(recordings):
         try:
             data = insert_all_in_transaction(recordings)
             success = True
+            for recording in recordings:
+                db_recording.cluster_new_recording(recording)
         except sqlalchemy.exc.IntegrityError as e:
             # If we get an IntegrityError then our transaction failed.
             # We should try again
@@ -46,4 +49,5 @@ def insert_all_in_transaction(recordings):
         for recording in recordings:
             result = insert_single(connection, recording)
             ret.append(result)
+
     return ret

--- a/messybrainz/cluster/cluster.py
+++ b/messybrainz/cluster/cluster.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+import pika
+import sys
+import ujson
+from brainzutils import musicbrainz_db
+from brainzutils.musicbrainz_db.exceptions import NoDataFoundException
+from flask import current_app
+from messybrainz.cluster import utils
+from messybrainz import db
+from messybrainz.db import data
+from messybrainz.db import artist as db_artist
+from messybrainz.db import recording as db_recording
+from messybrainz.db import release as db_release
+from messybrainz.webserver import create_app
+from sqlalchemy.exc import IntegrityError
+from uuid import UUID
+
+
+class Cluster:
+    def __init__(self):
+        self.connection = None
+        self.incoming_ch = None
+        self.unique_ch = None
+        self.ERROR_RETRY_DELAY = 3 # number of seconds to wait until retrying an operation
+
+
+    @staticmethod
+    def static_callback(ch, method, properties, body, obj):
+        return obj.callback(ch, method, properties, body)
+
+
+    def connect_to_rabbitmq(self):
+        connection_config = {
+            'username': current_app.config['RABBITMQ_USERNAME'],
+            'password': current_app.config['RABBITMQ_PASSWORD'],
+            'host': current_app.config['RABBITMQ_HOST'],
+            'port': current_app.config['RABBITMQ_PORT'],
+            'virtual_host': current_app.config['RABBITMQ_VHOST'],
+        }
+        self.connection = utils.connect_to_rabbitmq(**connection_config,
+                                                    error_logger=current_app.logger.error,
+                                                    error_retry_delay=self.ERROR_RETRY_DELAY)
+
+
+    def callback(self, ch, method, properties, body):
+        self.cluster_recording(body)
+        while True:
+            try:
+                self.incoming_ch.basic_ack(delivery_tag = method.delivery_tag)
+                break
+            except pika.exceptions.ConnectionClosed:
+                self.connect_to_rabbitmq()
+
+
+    def cluster_recording(self, rec):
+
+        rec_data = ujson.loads(rec)
+        if 'recording_mbid' in rec_data:
+            try:
+                with db.engine.begin() as connection:
+                    cluster_id = db_recording.get_recording_cluster_id_using_recording_mbid(connection, rec_data['recording_mbid'])
+                    msid = data.get_id_from_recording(connection, rec_data)
+                    if cluster_id:
+                        db_recording.insert_recording_cluster(connection, cluster_id, [msid])
+                    else:
+                        db_recording.insert_recording_cluster(connection, msid, [msid])
+                        db_recording.link_recording_mbid_to_recording_msid(connection, msid, rec_data['recording_mbid'])
+
+                    if 'artist_mbids' not in rec_data:
+                        try:
+                            artist_mbids = db_artist.fetch_artist_mbids(connection, rec_data['recording_mbid'])
+                            artist_mbids = [UUID(artist_mbid) for artist_mbid in artist_mbids]
+                            artist_mbids.sort()
+
+                            cluster_id = db_artist.get_artist_cluster_id_using_artist_mbids(connection, artist_mbids)
+                            msid = data.get_artist_credit(connection, rec_data['artist'])
+                            if cluster_id:
+                                db_artist.insert_artist_credit_cluster(connection, cluster_id, [msid])
+                            else:
+                                db_artist.insert_artist_credit_cluster(connection, msid, [msid])
+                                db_artist.link_artist_mbids_to_artist_credit_cluster_id(connection, msid, artist_mbids)
+                        except (IntegrityError, NoDataFoundException):
+                            pass
+
+                    if 'release' in rec_data and 'release_mbid' not in rec_data:
+                        try:
+                            releases = db_release.fetch_releases_from_musicbrainz_db(connection, rec_data['recording_mbid'])
+                            for release in releases:
+                                if release['name'] == rec_data['release']:
+                                    cluster_id = db_release.get_release_cluster_id_using_release_mbid(connection, release['id'])
+                                    msid = data.get_release(connection, rec_data['release'])
+                                    if cluster_id:
+                                        db_release.insert_release_cluster(connection, cluster_id, [msid])
+                                    else:
+                                        db_release.insert_release_cluster(connection, msid, [msid])
+                                        db_release.link_release_mbid_to_release_msid(connection, msid, release['id'])
+                        except (IntegrityError, NoDataFoundException):
+                            pass
+            except IntegrityError:
+                pass
+
+        if 'artist_mbids' in rec_data:
+            artist_mbids = [UUID(artist_mbid) for artist_mbid in rec_data['artist_mbids']]
+            try:
+                with db.engine.begin() as connection:
+                    cluster_id = db_artist.get_artist_cluster_id_using_artist_mbids(connection, artist_mbids)
+                    msid = data.get_artist_credit(connection, rec_data['artist'])
+                    if cluster_id:
+                        db_artist.insert_artist_credit_cluster(connection, cluster_id, [msid])
+                    else:
+                        db_artist.insert_artist_credit_cluster(connection, msid, [msid])
+                        db_artist.link_artist_mbids_to_artist_credit_cluster_id(connection, msid, artist_mbids)
+            except IntegrityError:
+                pass
+
+        if 'release_mbid' in rec_data and 'release' in rec_data:
+            try:
+                with db.engine.begin() as connection:
+                    cluster_id = db_release.get_release_cluster_id_using_release_mbid(connection, rec_data['release_mbid'])
+                    msid = data.get_release(connection, rec_data['release'])
+                    if cluster_id:
+                        db_release.insert_release_cluster(connection, cluster_id, [msid])
+                    else:
+                        db_release.insert_release_cluster(connection, msid, [msid])
+                        db_release.link_release_mbid_to_release_msid(connection, msid, rec_data['release_mbid'])
+            except IntegrityError:
+                pass
+
+        while True:
+            try:
+                self.unique_ch.basic_publish(
+                    exchange=current_app.config['UNIQUE_EXCHANGE'],
+                    routing_key='',
+                    body=rec,
+                    properties=pika.BasicProperties(delivery_mode = 2,),
+                )
+                break
+            except pika.exceptions.ConnectionClosed:
+                self.connect_to_rabbitmq()
+        
+
+    def _verify_hosts_in_config(self):
+        if "RABBITMQ_HOST" not in current_app.config:
+            current_app.logger.critical("RabbitMQ service not defined. Sleeping {0} seconds and exiting.".format(self.ERROR_RETRY_DELAY))
+            time.sleep(self.ERROR_RETRY_DELAY)
+            sys.exit(-1)
+
+
+    def start(self):
+        app = create_app()
+        with app.app_context():
+            current_app.logger.info("cluster init")
+            self._verify_hosts_in_config()
+
+            while True:
+                try:
+                    db.init_db_engine(current_app.config['SQLALCHEMY_DATABASE_URI'])
+                    break
+                except Exception as err:
+                    current_app.logger.error("Cannot connect to db: %s. Retrying in 2 seconds and trying again." % str(err), exc_info=True)
+                    sleep(self.ERROR_RETRY_DELAY)
+
+            while True:
+                try:
+                    musicbrainz_db.init_db_engine(current_app.config['MB_DATABASE_URI'])
+                    break
+                except Exception as err:
+                    current_app.logger.error("Cannot connect to MusicBrainz db: %s. Retrying in 2 seconds and trying again." % str(err), exc_info=True)
+                    sleep(self.ERROR_RETRY_DELAY)
+
+            while True:
+                self.connect_to_rabbitmq()
+                self.incoming_ch = self.connection.channel()
+                self.incoming_ch.exchange_declare(exchange=current_app.config['INCOMING_EXCHANGE'], exchange_type='fanout')
+                self.incoming_ch.queue_declare(current_app.config['INCOMING_QUEUE'], durable=True)
+                self.incoming_ch.queue_bind(exchange=current_app.config['INCOMING_EXCHANGE'], queue=current_app.config['INCOMING_QUEUE'])
+                self.incoming_ch.basic_consume(
+                    lambda ch, method, properties, body: self.static_callback(ch, method, properties, body, obj=self),
+                    queue=current_app.config['INCOMING_QUEUE'],
+                )
+
+                self.unique_ch = self.connection.channel()
+                self.unique_ch.exchange_declare(exchange=current_app.config['UNIQUE_EXCHANGE'], exchange_type='fanout')
+
+                current_app.logger.info("Clustering started")
+                try:
+                    self.incoming_ch.start_consuming()
+                except pika.exceptions.ConnectionClosed:
+                    current_app.logger.warn("Connection to rabbitmq closed. Re-opening.", exc_info=True)
+                    self.connection = None
+                    continue
+
+                self.connection.close()
+
+
+if __name__ == "__main__":
+    cl = Cluster()
+    cl.start()

--- a/messybrainz/cluster/utils.py
+++ b/messybrainz/cluster/utils.py
@@ -1,0 +1,37 @@
+import os
+import pika
+import time
+
+
+def connect_to_rabbitmq(username, password,
+                        host, port, virtual_host,
+                        connection_type=pika.BlockingConnection,
+                        credentials_type=pika.PlainCredentials,
+                        error_logger=print,
+                        error_retry_delay=3):
+    """Connects to RabbitMQ
+
+    Args:
+        username, password, host, port, virtual_host
+        error_logger: A function used to log failed connections.
+        connection_type: A pika Connection class to instantiate.
+        credentials_type: A pika Credentials class to use.
+        error_retry_delay: How long to wait in seconds before retrying a connection.
+
+    Returns:
+        A connection, with type of connection_type.
+    """
+    while True:
+        try:
+            credentials = credentials_type(username, password)
+            connection_parameters = pika.ConnectionParameters(
+                host=host,
+                port=port,
+                virtual_host=virtual_host,
+                credentials=credentials,
+            )
+            return connection_type(connection_parameters)
+        except Exception as err:
+            error_message = "Cannot connect to RabbitMQ: {error}, retrying in {delay} seconds."
+            error_logger(error_message.format(error=str(err), delay=error_retry_delay))
+            time.sleep(error_retry_delay)

--- a/messybrainz/custom_config.py.sample
+++ b/messybrainz/custom_config.py.sample
@@ -38,11 +38,9 @@ RABBITMQ_USERNAME = "guest"
 RABBITMQ_PASSWORD = "guest"
 RABBITMQ_VHOST = "/"
 
-# RabbitMQ exchanges and queues
+# RabbitMQ exchange and queue
 INCOMING_EXCHANGE = "incoming"
 INCOMING_QUEUE = "incoming"
-UNIQUE_EXCHANGE = "unique"
-UNIQUE_QUEUE = "unique"
 
 # LOGGING
 

--- a/messybrainz/custom_config.py.sample
+++ b/messybrainz/custom_config.py.sample
@@ -31,6 +31,18 @@ REDIS_HOST = "redis"
 REDIS_PORT = 6379
 REDIS_NAMESPACE = "messybrainz"
 
+# RabbitMQ
+RABBITMQ_HOST = "rabbitmq"
+RABBITMQ_PORT = 5672
+RABBITMQ_USERNAME = "guest"
+RABBITMQ_PASSWORD = "guest"
+RABBITMQ_VHOST = "/"
+
+# RabbitMQ exchanges and queues
+INCOMING_EXCHANGE = "incoming"
+INCOMING_QUEUE = "incoming"
+UNIQUE_EXCHANGE = "unique"
+UNIQUE_QUEUE = "unique"
 
 # LOGGING
 

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -142,6 +142,7 @@ def link_artist_mbids_to_artist_credit_cluster_id(connection, cluster_id, artist
     connection.execute(text("""
         INSERT INTO artist_credit_redirect (artist_credit_cluster_id, artist_mbids_array)
              VALUES (:cluster_id, array_sort(:artist_credit_mbids))
+        ON CONFLICT (artist_credit_cluster_id, artist_mbids_array) DO NOTHING
     """), {
         "cluster_id": cluster_id,
         "artist_credit_mbids": artist_credit_mbids,
@@ -172,6 +173,7 @@ def insert_artist_credit_cluster(connection, cluster_id, artist_credit_gids):
     connection.execute(text("""
         INSERT INTO artist_credit_cluster (cluster_id, artist_credit_gid, updated)
              VALUES (:cluster_id, :artist_credit_gid, now())
+        ON CONFLICT (cluster_id, artist_credit_gid) DO NOTHING
     """), values
     )
 

--- a/messybrainz/db/exceptions.py
+++ b/messybrainz/db/exceptions.py
@@ -13,3 +13,7 @@ class BadDataException(MessyBrainzException):
 class ErrorAddingException(MessyBrainzException):
     """Should be used when incorrect data is being submitted."""
     pass
+
+class ErrorAssociatingRecording(MessyBrainzException):
+    """Should be used if error occured during associating MSID to MBID for new recording."""
+    pass

--- a/messybrainz/db/recording.py
+++ b/messybrainz/db/recording.py
@@ -163,6 +163,8 @@ def create_recording_clusters():
 
 def cluster_new_recording(recording_data):
     """ Tries to associate and cluster newly inserted recording.
+        The recordings are send to rabbitMQ server and are consumed by
+        clustering script.
 
     Args:
         recording_data(dict): Data present in the recording.

--- a/messybrainz/db/recording.py
+++ b/messybrainz/db/recording.py
@@ -180,16 +180,16 @@ def cluster_new_recording(recording_data):
 
 
 def _send_recording_to_queue(recording_data):
-    # check if rabbitmq connection exists or not
-    # and if not then try to connect
-    try:
-        rabbitmq_connection.init_rabbitmq_connection(current_app)
-    except ConnectionError as e:
-        current_app.logger.error('Cannot connect to RabbitMQ: %s' % str(e))
-        raise ServiceUnavailable('Cannot submit recording to queue, please try again later.')
-
     app = create_app()
     with app.app_context():
+        # check if rabbitmq connection exists or not
+        # and if not then try to connect
+        try:
+            rabbitmq_connection.init_rabbitmq_connection(current_app)
+        except ConnectionError as e:
+            current_app.logger.error('Cannot connect to RabbitMQ: %s' % str(e))
+            raise ServiceUnavailable('Cannot submit recording to queue, please try again later.')
+
         publish_data_to_queue(
             data=recording_data,
             exchange=current_app.config['INCOMING_EXCHANGE'],

--- a/messybrainz/db/release.py
+++ b/messybrainz/db/release.py
@@ -22,8 +22,9 @@ def insert_release_cluster(connection, cluster_id, release_gids):
     connection.execute(text("""
         INSERT INTO release_cluster (cluster_id, release_gid, updated)
              VALUES (:cluster_id, :release_gid, now())
-        """), values
-        )
+        ON CONFLICT (cluster_id, release_gid) DO NOTHING
+    """), values
+    )
 
 
 def insert_releases_to_recording_release_join(connection, recording_mbid, releases):
@@ -111,6 +112,7 @@ def link_release_mbid_to_release_msid(connection, cluster_id, mbid):
     connection.execute(text("""
         INSERT INTO release_redirect (release_cluster_id, release_mbid)
              VALUES (:cluster_id, :mbid)
+        ON CONFLICT (release_cluster_id, release_mbid) DO NOTHING
     """), {
         "cluster_id": cluster_id,
         "mbid": mbid,

--- a/messybrainz/db/tests/test_artist.py
+++ b/messybrainz/db/tests/test_artist.py
@@ -1,6 +1,6 @@
 from messybrainz import data
 from messybrainz import db
-from messybrainz import submit_listens_and_sing_me_a_sweet_song as submit_listens
+from messybrainz import insert_all_in_transaction as submit_listens
 from messybrainz.db import artist
 from messybrainz.db.testing import DatabaseTestCase
 from unittest.mock import patch

--- a/messybrainz/db/tests/test_recording.py
+++ b/messybrainz/db/tests/test_recording.py
@@ -1,5 +1,5 @@
 import json
-from messybrainz import submit_listens_and_sing_me_a_sweet_song as submit_listens
+from messybrainz import insert_all_in_transaction as submit_listens
 from messybrainz import db
 from messybrainz.db import data
 from messybrainz.db.testing import DatabaseTestCase

--- a/messybrainz/db/tests/test_release.py
+++ b/messybrainz/db/tests/test_release.py
@@ -1,5 +1,5 @@
 import json
-from messybrainz import submit_listens_and_sing_me_a_sweet_song as submit_listens
+from messybrainz import insert_all_in_transaction as submit_listens
 from messybrainz import db
 from messybrainz.db import data
 from messybrainz.db.testing import DatabaseTestCase

--- a/messybrainz/default_config.py
+++ b/messybrainz/default_config.py
@@ -36,11 +36,9 @@ RABBITMQ_USERNAME = "guest"
 RABBITMQ_PASSWORD = "guest"
 RABBITMQ_VHOST = "/"
 
-# RabbitMQ exchanges and queues
+# RabbitMQ exchange and queue
 INCOMING_EXCHANGE = "incoming"
 INCOMING_QUEUE = "incoming"
-UNIQUE_EXCHANGE = "unique"
-UNIQUE_QUEUE = "unique"
 
 # LOGGING
 

--- a/messybrainz/default_config.py
+++ b/messybrainz/default_config.py
@@ -29,6 +29,18 @@ REDIS_HOST = "redis"
 REDIS_PORT = 6379
 REDIS_NAMESPACE = "messybrainz"
 
+# RabbitMQ
+RABBITMQ_HOST = "rabbitmq"
+RABBITMQ_PORT = 5672
+RABBITMQ_USERNAME = "guest"
+RABBITMQ_PASSWORD = "guest"
+RABBITMQ_VHOST = "/"
+
+# RabbitMQ exchanges and queues
+INCOMING_EXCHANGE = "incoming"
+INCOMING_QUEUE = "incoming"
+UNIQUE_EXCHANGE = "unique"
+UNIQUE_QUEUE = "unique"
 
 # LOGGING
 

--- a/messybrainz/webserver/__init__.py
+++ b/messybrainz/webserver/__init__.py
@@ -6,6 +6,15 @@ from brainzutils.flask import CustomFlask
 from messybrainz import db
 
 
+def create_rabbitmq(app):
+    from messybrainz.webserver.rabbitmq_connection import init_rabbitmq_connection
+    try:
+        init_rabbitmq_connection(app)
+    except ConnectionError as e:
+        app.logger.error('Could not connect to RabbitMQ: %s', str(e))
+        return
+
+
 def create_app(debug=None, config_path=None):
     app = CustomFlask(
         import_name=__name__,
@@ -49,6 +58,9 @@ def create_app(debug=None, config_path=None):
         email_config=app.config.get('LOG_EMAIL'),
         sentry_config=app.config.get('LOG_SENTRY')
     )
+
+    # RabbitMQ connection
+    create_rabbitmq(app)
 
     # Extensions
     from flask_uuid import FlaskUUID

--- a/messybrainz/webserver/rabbitmq_connection.py
+++ b/messybrainz/webserver/rabbitmq_connection.py
@@ -1,3 +1,4 @@
+from requests.exceptions import ConnectionError
 from time import sleep
 import pika
 import pika_pool

--- a/messybrainz/webserver/rabbitmq_connection.py
+++ b/messybrainz/webserver/rabbitmq_connection.py
@@ -1,4 +1,3 @@
-import sys
 from time import sleep
 import pika
 import pika_pool

--- a/messybrainz/webserver/rabbitmq_connection.py
+++ b/messybrainz/webserver/rabbitmq_connection.py
@@ -1,0 +1,37 @@
+import sys
+from time import sleep
+import pika
+import pika_pool
+
+_rabbitmq = None
+
+def init_rabbitmq_connection(app):
+    """Initialize the webserver rabbitmq connection.
+
+    This initializes _rabbitmq as a connection pool from which new RabbitMQ
+    connections can be acquired.
+    """
+    global _rabbitmq
+
+    if _rabbitmq is not None:
+        return
+
+    if "RABBITMQ_HOST" not in app.config:
+        raise ConnectionError("Cannot connect to RabbitMQ: host and port not defined")
+
+    connection_parameters = pika.ConnectionParameters(
+        host=app.config['RABBITMQ_HOST'],
+        port=app.config['RABBITMQ_PORT'],
+        virtual_host=app.config['RABBITMQ_VHOST'],
+        credentials=pika.PlainCredentials(app.config['RABBITMQ_USERNAME'], app.config['RABBITMQ_PASSWORD']),
+    )
+
+    _rabbitmq = pika_pool.QueuedPool(
+        create=lambda: pika.BlockingConnection(connection_parameters),
+        max_size=100,
+        max_overflow=10,
+        timeout=10,
+        recycle=3600,
+        stale=45,
+    )
+    app.logger.info('Connection to RabbitMQ established!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ Werkzeug == 0.10.4
 click == 4.1
 coverage == 4.4.1
 nose == 1.3.7
+pika == 0.11.0
+git+https://github.com/bninja/pika-pool.git@5b1d3b650395aed60d9995fbfd289de7e62fe8d5#egg=pika_pool
 psycopg2 == 2.7.3.2
 redis == 2.10.3
 raven[flask] == 5.5.0


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MessyBrainz. We appreciate
    your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.
-->

# Summary
Created script to cluster incoming recordings.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other

# Problem
The recordings that are being submitted should be clustered as those are inserted. It's a lot of computation to cluster those recordings after those have been inserted.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-384](https://tickets.metabrainz.org/browse/LB-384)


# Solution
Created a script cluster.py which runs continuously and creates clusters for the recordings sent via rabbitMQ server. As the computation to create a cluster is significant so we can't just let recordings be clustered without queueing up.