### PR TITLE
LB-386: MessyBrainz: Check corner cases for empty MBID fields.

### DIFF
--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -125,6 +125,7 @@ def fetch_unclustered_distinct_artist_credit_mbids(connection):
               LEFT JOIN artist_credit_cluster AS acc
                      ON r.artist = acc.artist_credit_gid
                   WHERE rj.data ->> 'artist_mbids' IS NOT NULL
+                    AND rj.data ->> 'artist_mbids' != '[]'
                     AND acc.artist_credit_gid IS NULL
     """))
 
@@ -214,12 +215,15 @@ def get_artist_cluster_id_using_artist_mbids(connection, artist_credit_mbids):
        to the given artist MBIDs.
     """
 
-    # array_sort is a custom function for implementation
-    # details check admin/sql/create_functions.sql
+    artist_credit_mbids.sort()
     gid = connection.execute(text("""
         SELECT artist_credit_cluster_id
           FROM artist_credit_redirect
+<<<<<<< HEAD
          WHERE artist_mbids = array_sort(:artist_credit_mbids)
+=======
+         WHERE artist_mbids_array = :artist_credit_mbids
+>>>>>>> Add conditions to ignore recordings with empty MBIDs
     """), {
         "artist_credit_mbids": artist_credit_mbids,
     })
@@ -246,7 +250,8 @@ def fetch_artist_credits_left_to_cluster(connection):
               LEFT JOIN artist_credit_redirect AS acr
                      ON convert_json_array_to_sorted_uuid_array(rj.data -> 'artist_mbids') = acr.artist_mbids
                   WHERE rj.data ->> 'artist_mbids' IS NOT NULL
-                    AND acr.artist_mbids IS NULL
+                    AND rj.data ->> 'artist_mbids' != '[]'
+                    AND acr.artist_mbids_array IS NULL
     """))
 
     return [r[0] for r in result]

--- a/messybrainz/db/artist.py
+++ b/messybrainz/db/artist.py
@@ -219,11 +219,7 @@ def get_artist_cluster_id_using_artist_mbids(connection, artist_credit_mbids):
     gid = connection.execute(text("""
         SELECT artist_credit_cluster_id
           FROM artist_credit_redirect
-<<<<<<< HEAD
          WHERE artist_mbids = array_sort(:artist_credit_mbids)
-=======
-         WHERE artist_mbids_array = :artist_credit_mbids
->>>>>>> Add conditions to ignore recordings with empty MBIDs
     """), {
         "artist_credit_mbids": artist_credit_mbids,
     })
@@ -251,7 +247,7 @@ def fetch_artist_credits_left_to_cluster(connection):
                      ON convert_json_array_to_sorted_uuid_array(rj.data -> 'artist_mbids') = acr.artist_mbids
                   WHERE rj.data ->> 'artist_mbids' IS NOT NULL
                     AND rj.data ->> 'artist_mbids' != '[]'
-                    AND acr.artist_mbids_array IS NULL
+                    AND acr.artist_mbids IS NULL
     """))
 
     return [r[0] for r in result]

--- a/messybrainz/db/recording.py
+++ b/messybrainz/db/recording.py
@@ -65,7 +65,7 @@ def fetch_distinct_recording_mbids(connection):
         SELECT DISTINCT rj.data ->> 'recording_mbid'
                    FROM recording_json AS rj
               LEFT JOIN recording_cluster AS rc
-                     ON (rj.data ->> 'recording_mbid')::uuid = rc.recording_gid
+                     ON (rj.data ->> 'recording_mbid') = rc.recording_gid::text
                   WHERE rj.data ->> 'recording_mbid' IS NOT NULL
                     AND rc.recording_gid IS NULL
     """))

--- a/messybrainz/db/release.py
+++ b/messybrainz/db/release.py
@@ -93,6 +93,8 @@ def fetch_unclustered_distinct_release_mbids(connection):
               LEFT JOIN release_cluster AS relc
                      ON rec.release = relc.release_gid
                   WHERE recj.data ->> 'release_mbid' IS NOT NULL
+                    AND recj.data ->> 'release_mbid' != ''
+                    AND recj.data ->> 'release' IS NOT NULL
                     AND relc.release_gid IS NULL
     """))
 
@@ -165,6 +167,8 @@ def fetch_release_left_to_cluster(connection):
               LEFT JOIN release_redirect AS relr
                      ON (recj.data ->> 'release_mbid')::uuid = relr.release_mbid
                   WHERE recj.data ->> 'release_mbid' IS NOT NULL
+                    AND recj.data ->> 'release_mbid' != ''
+                    AND recj.data ->> 'release' IS NOT NULL
                     AND relr.release_mbid IS NULL
     """))
 
@@ -329,8 +333,9 @@ def fetch_recording_mbids_not_in_recording_release_join(connection):
         SELECT DISTINCT recj.data ->> 'recording_mbid'
                    FROM recording_json AS recj
               LEFT JOIN recording_release_join AS rrj
-                     ON (recj.data ->> 'recording_mbid')::uuid = rrj.recording_mbid
+                     ON (recj.data ->> 'recording_mbid') = rrj.recording_mbid::text
                   WHERE recj.data ->> 'recording_mbid' IS NOT NULL
+                    AND recj.data ->> 'recording_mbid' != ''
                     AND rrj.recording_mbid IS NULL
     """))
 


### PR DESCRIPTION
# Summary
Add conditions to ignore recordings with empty MBIDs
We have recordings in recording_json with MBIDs pointing to
empty strings or empty lists which should be ignored.

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
In recording JSON table we have recording_mbid='' and artist_mbids='[]' and release_mbid = ''. And also release which don't contain release name but contain release MBID. So, we need to handle these cases.
<!-- 
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [LB-386](https://tickets.metabrainz.org/browse/LB-386)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Modify queries to handle those cases.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->


