### PR TITLE
Migrate the recording_json table to use JSONB

### DIFF
--- a/admin/sql/create_functions.sql
+++ b/admin/sql/create_functions.sql
@@ -12,15 +12,15 @@ END
 $sorted_array$ LANGUAGE plpgsql IMMUTABLE;
 
 -- Returns an sorted UUID array for an input JSON array
-CREATE OR REPLACE FUNCTION convert_json_array_to_sorted_uuid_array(json)
+CREATE OR REPLACE FUNCTION convert_json_array_to_sorted_uuid_array(jsonb)
 RETURNS uuid[] AS $converted_array$
-DECLARE 
+DECLARE
     converted_array uuid[];
 BEGIN
-    SELECT array_sort(array_agg(elements)::uuid[]) || ARRAY[]::uuid[] INTO converted_array 
-    FROM json_array_elements_text($1) elements;
+    SELECT array_sort(array_agg(elements)::uuid[]) || ARRAY[]::uuid[] INTO converted_array
+    FROM jsonb_array_elements_text($1) elements;
     RETURN converted_array;
-END 
+END
 $converted_array$ LANGUAGE plpgsql IMMUTABLE;
 
 COMMIT;

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -32,7 +32,7 @@ CREATE INDEX release_cluster_id_ndx_recording_redirect ON release_redirect (rele
 CREATE INDEX recording_mbid_ndx_recording_json ON recording_json ((data ->> 'recording_mbid'));
 CREATE INDEX artist_mbid_ndx_recording_json ON recording_json ((data ->> 'artist_mbids'));
 CREATE INDEX release_mbid_ndx_recording_json ON recording_json ((data ->> 'release_mbid'));
-CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array(data -> 'artist_mbids'));
+CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array((data -> 'artist_mbids')::JSON));
 
 CREATE INDEX artist_ndx_recording ON recording (artist);
 CREATE INDEX release_ndx_recording ON recording (release);

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -32,7 +32,7 @@ CREATE INDEX release_cluster_id_ndx_recording_redirect ON release_redirect (rele
 CREATE INDEX recording_mbid_ndx_recording_json ON recording_json ((data ->> 'recording_mbid'));
 CREATE INDEX artist_mbid_ndx_recording_json ON recording_json ((data ->> 'artist_mbids'));
 CREATE INDEX release_mbid_ndx_recording_json ON recording_json ((data ->> 'release_mbid'));
-CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array((data -> 'artist_mbids')::JSON));
+CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array((data -> 'artist_mbids')));
 
 CREATE INDEX artist_ndx_recording ON recording (artist);
 CREATE INDEX release_ndx_recording ON recording (release);

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -26,7 +26,7 @@ CREATE TABLE recording (
   id         SERIAL,
   gid        UUID    NOT NULL,
   data       INTEGER NOT NULL, -- FK to recording_json.id
-  artist     UUID    NOT NULL, -- FK to artist.gid
+  artist     UUID    NOT NULL, -- FK to artist_credit.gid
   release    UUID,             -- FK to release.gid
   submitted  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -46,7 +46,7 @@ ALTER TABLE recording_cluster ADD CONSTRAINT recording_cluster_uniq UNIQUE (clus
 
 CREATE TABLE recording_json (
   id          SERIAL,
-  data        JSON     NOT NULL,
+  data        JSONB    NOT NULL,
   data_sha256 CHAR(64) NOT NULL,
   meta_sha256 CHAR(64) NOT NULL
 );

--- a/admin/sql/updates/2019-06-13-migrate-to-jsonb.sql
+++ b/admin/sql/updates/2019-06-13-migrate-to-jsonb.sql
@@ -45,9 +45,12 @@ BEGIN
 END
 $converted_array$ LANGUAGE plpgsql IMMUTABLE;
 
+DROP INDEX data_sha256_ndx_recording_json;
+DROP INDEX meta_sha256_ndx_recording_json;
+
 CREATE UNIQUE INDEX data_sha256_ndx_recording_json ON recording_json (data_sha256);
 CREATE INDEX meta_sha256_ndx_recording_json ON recording_json (meta_sha256);
-CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array((data -> 'artist_mbids')::JSON));
+CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array((data -> 'artist_mbids')::JSONB));
 CREATE INDEX recording_mbid_ndx_recording_json ON recording_json ((data ->> 'recording_mbid'));
 CREATE INDEX artist_mbid_ndx_recording_json ON recording_json ((data ->> 'artist_mbids'));
 CREATE INDEX release_mbid_ndx_recording_json ON recording_json ((data ->> 'release_mbid'));

--- a/admin/sql/updates/2019-06-13-migrate-to-jsonb.sql
+++ b/admin/sql/updates/2019-06-13-migrate-to-jsonb.sql
@@ -25,7 +25,7 @@ BEGIN
 END
 $sorted_array$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION convert_json_array_to_sorted_uuid_array(json)
+CREATE OR REPLACE FUNCTION convert_json_array_to_sorted_uuid_array(jsonb)
 RETURNS uuid[] AS $converted_array$
 DECLARE
     converted_array uuid[];
@@ -36,7 +36,7 @@ BEGIN
 END
 $converted_array$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array((data -> 'artist_mbids')::JSON));
+CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array((data -> 'artist_mbids')));
 CREATE INDEX recording_mbid_ndx_recording_json ON recording_json ((data ->> 'recording_mbid'));
 CREATE INDEX artist_mbid_ndx_recording_json ON recording_json ((data ->> 'artist_mbids'));
 CREATE INDEX release_mbid_ndx_recording_json ON recording_json ((data ->> 'release_mbid'));

--- a/admin/sql/updates/2019-06-13-migrate-to-jsonb.sql
+++ b/admin/sql/updates/2019-06-13-migrate-to-jsonb.sql
@@ -1,0 +1,51 @@
+BEGIN;
+
+ALTER TABLE recording DROP CONSTRAINT recording_fk_recording_json;
+
+ALTER TABLE recording_json RENAME TO recording_json_tofix;
+
+SELECT id, regexp_replace(data::text, '\\u0000', '', 'g')::JSONB AS data, data_sha256, meta_sha256 
+  INTO recording_json 
+  FROM recording_json_tofix;
+
+ALTER TABLE recording_json
+  ALTER COLUMN data
+  SET DATA TYPE jsonb
+  USING data::jsonb;
+
+ALTER TABLE recording_json ADD CONSTRAINT recording_json_pkey PRIMARY KEY (id);
+
+CREATE OR REPLACE FUNCTION array_sort(uuid[])
+RETURNS uuid[] AS $sorted_array$
+DECLARE
+    sorted_array uuid[];
+BEGIN
+    SELECT ARRAY(SELECT unnest($1) ORDER BY 1) INTO sorted_array;
+    RETURN sorted_array;
+END
+$sorted_array$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION convert_json_array_to_sorted_uuid_array(json)
+RETURNS uuid[] AS $converted_array$
+DECLARE
+    converted_array uuid[];
+BEGIN
+    SELECT array_sort(array_agg(elements)::uuid[]) || ARRAY[]::uuid[] INTO converted_array
+    FROM json_array_elements_text($1) elements;
+    RETURN converted_array;
+END
+$converted_array$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE INDEX artist_mbid_array_ndx_recording_json ON recording_json (convert_json_array_to_sorted_uuid_array((data -> 'artist_mbids')::JSON));
+CREATE INDEX recording_mbid_ndx_recording_json ON recording_json ((data ->> 'recording_mbid'));
+CREATE INDEX artist_mbid_ndx_recording_json ON recording_json ((data ->> 'artist_mbids'));
+CREATE INDEX release_mbid_ndx_recording_json ON recording_json ((data ->> 'release_mbid'));
+
+ALTER TABLE recording
+  ADD CONSTRAINT recording_fk_recording_json
+  FOREIGN KEY (data)
+  REFERENCES recording_json (id);
+
+DROP TABLE recording_json_tofix;
+
+COMMIT;

--- a/admin/sql/updates/2019-06-13-migrate-to-jsonb.sql
+++ b/admin/sql/updates/2019-06-13-migrate-to-jsonb.sql
@@ -31,7 +31,7 @@ DECLARE
     converted_array uuid[];
 BEGIN
     SELECT array_sort(array_agg(elements)::uuid[]) || ARRAY[]::uuid[] INTO converted_array
-    FROM json_array_elements_text($1) elements;
+    FROM jsonb_array_elements_text($1) elements;
     RETURN converted_array;
 END
 $converted_array$ LANGUAGE plpgsql IMMUTABLE;

--- a/messybrainz/db/testing.py
+++ b/messybrainz/db/testing.py
@@ -34,6 +34,7 @@ class DatabaseTestCase(unittest.TestCase):
 
     def setUp(self):
         db.init_db_engine(config.POSTGRES_ADMIN_URI)
+        self.drop_db()
         self.create_db()
         db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
         self.init_db()
@@ -62,6 +63,10 @@ class DatabaseTestCase(unittest.TestCase):
 
     def drop_tables(self):
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'drop_tables.sql'))
+
+
+    def drop_db(self):
+        db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'drop_db.sql'))
 
 
     def path_to_data_file(self, file_name):


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [x] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

The recording_json table was in the older JSON format and had invalid JSON records. This update script re-writes the table in a single transaction, re-creating all of the ids, FKs and indexes as needed.

We should be able to run this script at any time without interrupting other services.

However, this is based on the assumption that JSON and JSONB columns act in exactly the same way and no other existing code needs to be updated. Is this assumption valid?
